### PR TITLE
Adds relocatable timer driver for HPC SS

### DIFF
--- a/examples/headsail-bsp/examples/timer0.rs
+++ b/examples/headsail-bsp/examples/timer0.rs
@@ -1,22 +1,22 @@
 #![no_std]
 #![no_main]
 
-use headsail_bsp::{rt::entry, sprintln, timer_unit::*};
+use headsail_bsp::{rt::entry, sprintln, timer::{self, *}};
 
 #[entry]
 fn main() -> ! {
     sprintln!("Timer0 example");
-    let cnt_start = timer0_get_count();
+    let cnt_start = Timer0::get_count();
     sprintln!("Timer0 counter value at start: {}", cnt_start);
     sprintln!("Starting timer");
-    timer0_enable();
+    Timer0::enable();
     sprintln!("Wasting time...");
     for _i in 1..1_000_000 {
         continue;
     }
     sprintln!("Stopping timer");
-    timer0_disable();
-    let cnt_stop = timer0_get_count();
+    Timer0::disable();
+    let cnt_stop = Timer0::get_count();
     sprintln!("Timer0 counter value at stop: {}", cnt_stop);
     loop {}
 }

--- a/examples/headsail-bsp/src/apb_timer.rs
+++ b/examples/headsail-bsp/src/apb_timer.rs
@@ -44,7 +44,7 @@ impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS>{
         // Read register
         let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
         // Write 0 to bit 0 but leave all other bits untouched
-        reg.set_bit(Self::TIMER_ENABLE_BIT as usize, false);
+        reg.set_bit(Self::TIMER_ENABLE_BIT, false);
         // Write register back
         write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
     }

--- a/examples/headsail-bsp/src/apb_timer.rs
+++ b/examples/headsail-bsp/src/apb_timer.rs
@@ -1,4 +1,4 @@
-/**
+/*!
  * Date: 6/5/2024
  * Author: Andreas Stergiopoulos (andreas.stergiopoulos@tuni.fi)
  *
@@ -6,51 +6,60 @@
  * for this peripheral is the register map provided in the Headsail
  * gitlab pages.
  */
-use crate::{mmap::TIMER0_ADDR, read_u32, write_u32};
+use crate::{mmap::*, read_u32, write_u32};
 
 use bit_field::BitField;
 
-const TIMER0_COUNTER_REG_OFFSET: usize = 0x0;
-const TIMER0_CTRL_REG_OFFSET: usize = 0x4;
-const TIMER0_CMP_REG_OFFSET: usize = 0x8;
-const TIMER0_ENABLE_BIT: usize = 0b0;
+pub struct APBTimer<const BASE_ADDRESS: usize>;
 
-/**
- * Enables the timer (starts counting).
- */
-#[inline]
-pub fn timer0_enable() {
-    // Read register
-    let mut reg = read_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET);
-    // Make enable bit 1
-    reg.set_bit(TIMER0_ENABLE_BIT, true);
-    // Write register back
-    write_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET, reg);
+impl<const BASE_ADDRESS: usize> APBTimer<BASE_ADDRESS>{
+    const TIMER_COUNTER_REG_OFFSET: usize = 0x0;
+    const TIMER_CTRL_REG_OFFSET: usize = 0x4;
+    const TIMER_CMP_REG_OFFSET: usize = 0x8;
+    const TIMER_ENABLE_BIT: usize = 0b0;
+
+    /**
+     * Enables the timer (starts counting).
+     */
+    #[inline]
+    pub fn enable() {
+        // Read register
+        let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
+        // Make enable bit 1
+        reg.set_bit(Self::TIMER_ENABLE_BIT, true);
+        // Write register back
+        write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
+    }
+
+    /**
+     * Disables the timer (stops counting).
+     */
+    #[inline]
+    pub fn disable() {
+        // Read register
+        let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
+        // Write 0 to bit 0 but leave all other bits untouched
+        reg.set_bit(Self::TIMER_ENABLE_BIT as usize, false);
+        // Write register back
+        write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
+    }
+
+    /**
+     * Returns the timer counter (tick value).
+     */
+    #[inline]
+    pub fn get_count() -> u32 {
+        return read_u32(BASE_ADDRESS + Self::TIMER_COUNTER_REG_OFFSET);
+    }
+
+    #[inline]
+    #[cfg(debug_assertions)]
+    pub fn get_ctrl_reg() -> u32 {
+        return read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
+    }
 }
 
-/**
- * Disables the timer (stops counting).
- */
-#[inline]
-pub fn timer0_disable() {
-    // Read register
-    let mut reg = read_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET);
-    // Write 0 to bit 0 but leave all other bits untouched
-    reg.set_bit(TIMER0_ENABLE_BIT, false);
-    // Write register back
-    write_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET, reg);
-}
-
-/**
- * Returns the timer counter (tick value).
- */
-#[inline]
-pub fn timer0_get_count() -> u32 {
-    return read_u32(TIMER0_ADDR + TIMER0_COUNTER_REG_OFFSET);
-}
-
-#[inline]
-#[cfg(debug_assertions)]
-pub fn timer0_get_ctrl_reg() -> u32 {
-    return read_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET);
-}
+pub type Timer0 = APBTimer::<TIMER0_ADDR>;
+pub type Timer1 = APBTimer::<TIMER1_ADDR>;
+pub type Timer2 = APBTimer::<TIMER2_ADDR>;
+pub type Timer3 = APBTimer::<TIMER3_ADDR>;

--- a/examples/headsail-bsp/src/apb_timer.rs
+++ b/examples/headsail-bsp/src/apb_timer.rs
@@ -10,6 +10,11 @@ use crate::{mmap::*, read_u32, write_u32};
 
 use bit_field::BitField;
 
+/**
+ * Relocatable driver for the PULP APB Timer IP. The generic represents the 
+ * base address for the timer. This driver is ASIC only. For the Virtual 
+ * Prototype driver, please enable the "vp" feature.
+ */
 pub struct APBTimer<const BASE_ADDRESS: usize>;
 
 impl<const BASE_ADDRESS: usize> APBTimer<BASE_ADDRESS>{
@@ -52,6 +57,9 @@ impl<const BASE_ADDRESS: usize> APBTimer<BASE_ADDRESS>{
         return read_u32(BASE_ADDRESS + Self::TIMER_COUNTER_REG_OFFSET);
     }
 
+    /**
+     * Debug only method used to peek into the timer's control register.
+     */
     #[inline]
     #[cfg(debug_assertions)]
     pub fn get_ctrl_reg() -> u32 {
@@ -59,7 +67,11 @@ impl<const BASE_ADDRESS: usize> APBTimer<BASE_ADDRESS>{
     }
 }
 
+///Type alias that should be used to interface timer 0.
 pub type Timer0 = APBTimer::<TIMER0_ADDR>;
+///Type alias that should be used to interface timer 1.
 pub type Timer1 = APBTimer::<TIMER1_ADDR>;
+///Type alias that should be used to interface timer 2.
 pub type Timer2 = APBTimer::<TIMER2_ADDR>;
+///Type alias that should be used to interface timer 3.
 pub type Timer3 = APBTimer::<TIMER3_ADDR>;

--- a/examples/headsail-bsp/src/apb_timer.rs
+++ b/examples/headsail-bsp/src/apb_timer.rs
@@ -15,9 +15,9 @@ use bit_field::BitField;
  * base address for the timer. This driver is ASIC only. For the Virtual 
  * Prototype driver, please enable the "vp" feature.
  */
-pub struct APBTimer<const BASE_ADDRESS: usize>;
+pub struct ApbTimer<const BASE_ADDRESS: usize>;
 
-impl<const BASE_ADDRESS: usize> APBTimer<BASE_ADDRESS>{
+impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS>{
     const TIMER_COUNTER_REG_OFFSET: usize = 0x0;
     const TIMER_CTRL_REG_OFFSET: usize = 0x4;
     const TIMER_CMP_REG_OFFSET: usize = 0x8;
@@ -68,10 +68,10 @@ impl<const BASE_ADDRESS: usize> APBTimer<BASE_ADDRESS>{
 }
 
 ///Type alias that should be used to interface timer 0.
-pub type Timer0 = APBTimer::<TIMER0_ADDR>;
+pub type Timer0 = ApbTimer::<TIMER0_ADDR>;
 ///Type alias that should be used to interface timer 1.
-pub type Timer1 = APBTimer::<TIMER1_ADDR>;
+pub type Timer1 = ApbTimer::<TIMER1_ADDR>;
 ///Type alias that should be used to interface timer 2.
-pub type Timer2 = APBTimer::<TIMER2_ADDR>;
+pub type Timer2 = ApbTimer::<TIMER2_ADDR>;
 ///Type alias that should be used to interface timer 3.
-pub type Timer3 = APBTimer::<TIMER3_ADDR>;
+pub type Timer3 = ApbTimer::<TIMER3_ADDR>;

--- a/examples/headsail-bsp/src/apb_timer.rs
+++ b/examples/headsail-bsp/src/apb_timer.rs
@@ -11,13 +11,13 @@ use crate::{mmap::*, read_u32, write_u32};
 use bit_field::BitField;
 
 /**
- * Relocatable driver for the PULP APB Timer IP. The generic represents the 
- * base address for the timer. This driver is ASIC only. For the Virtual 
+ * Relocatable driver for the PULP APB Timer IP. The generic represents the
+ * base address for the timer. This driver is ASIC only. For the Virtual
  * Prototype driver, please enable the "vp" feature.
  */
 pub struct ApbTimer<const BASE_ADDRESS: usize>;
 
-impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS>{
+impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS> {
     const TIMER_COUNTER_REG_OFFSET: usize = 0x0;
     const TIMER_CTRL_REG_OFFSET: usize = 0x4;
     const TIMER_CMP_REG_OFFSET: usize = 0x8;
@@ -28,11 +28,9 @@ impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS>{
      */
     #[inline]
     pub fn enable() {
-        // Read register
         let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
         // Make enable bit 1
         reg.set_bit(Self::TIMER_ENABLE_BIT, true);
-        // Write register back
         write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
     }
 
@@ -41,11 +39,9 @@ impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS>{
      */
     #[inline]
     pub fn disable() {
-        // Read register
         let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
         // Write 0 to bit 0 but leave all other bits untouched
         reg.set_bit(Self::TIMER_ENABLE_BIT, false);
-        // Write register back
         write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
     }
 
@@ -68,10 +64,10 @@ impl<const BASE_ADDRESS: usize> ApbTimer<BASE_ADDRESS>{
 }
 
 ///Type alias that should be used to interface timer 0.
-pub type Timer0 = ApbTimer::<TIMER0_ADDR>;
+pub type Timer0 = ApbTimer<TIMER0_ADDR>;
 ///Type alias that should be used to interface timer 1.
-pub type Timer1 = ApbTimer::<TIMER1_ADDR>;
+pub type Timer1 = ApbTimer<TIMER1_ADDR>;
 ///Type alias that should be used to interface timer 2.
-pub type Timer2 = ApbTimer::<TIMER2_ADDR>;
+pub type Timer2 = ApbTimer<TIMER2_ADDR>;
 ///Type alias that should be used to interface timer 3.
-pub type Timer3 = ApbTimer::<TIMER3_ADDR>;
+pub type Timer3 = ApbTimer<TIMER3_ADDR>;

--- a/examples/headsail-bsp/src/lib.rs
+++ b/examples/headsail-bsp/src/lib.rs
@@ -4,6 +4,16 @@
 pub mod sprintln;
 pub mod uart;
 pub mod timer {
+    /*!
+     * Timer module for Headsail. When running on the Renode 
+     * Virtual Prototype, the "vp" feature should be enabled. 
+     * All operations are Read-Modify-Write.
+     * 
+     * HOW TO USE THIS DRIVER:
+     * In order to use any of the four timers that come with 
+     * Headsail HPC SubSystem, use the respective Timer{0..3} 
+     * type alias provided and the functions associated with it.
+     */
     #[cfg(not(feature = "vp"))]
     pub use crate::apb_timer::*;
     #[cfg(feature = "vp")]

--- a/examples/headsail-bsp/src/mmap.rs
+++ b/examples/headsail-bsp/src/mmap.rs
@@ -1,2 +1,5 @@
 pub(crate) const UART0_ADDR: usize = 0xFFF00000;
 pub(crate) const TIMER0_ADDR: usize = 0x5_0000;
+pub(crate) const TIMER1_ADDR: usize = 0x5_0010;
+pub(crate) const TIMER2_ADDR: usize = 0x5_0020;
+pub(crate) const TIMER3_ADDR: usize = 0x5_0030;

--- a/examples/headsail-bsp/src/timer_unit.rs
+++ b/examples/headsail-bsp/src/timer_unit.rs
@@ -7,7 +7,7 @@
  *
  * Documentation: https://github.com/pulp-platform/timer_unit/tree/master
  */
-use crate::{mmap::TIMER0_ADDR, read_u32, write_u32};
+use crate::{mmap::*, read_u32, write_u32};
 
 use bit_field::BitField;
 
@@ -60,3 +60,6 @@ impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
 }
 
 pub type Timer0 = TimerUnit::<TIMER0_ADDR>;
+pub type Timer1 = TimerUnit::<TIMER1_ADDR>;
+pub type Timer2 = TimerUnit::<TIMER2_ADDR>;
+pub type Timer3 = TimerUnit::<TIMER3_ADDR>;

--- a/examples/headsail-bsp/src/timer_unit.rs
+++ b/examples/headsail-bsp/src/timer_unit.rs
@@ -1,4 +1,4 @@
-/**
+/*!
  * Date: 6/5/2024
  * Author: Andreas Stergiopoulos (andreas.stergiopoulos@tuni.fi)
  *
@@ -11,6 +11,11 @@ use crate::{mmap::*, read_u32, write_u32};
 
 use bit_field::BitField;
 
+/**
+ * Relocatable driver for the PULP Timer Unit IP. The generic represents the 
+ * base address for the timer. This driver is for the Renode Virtual Prototype 
+ * only. For the ASIC driver, disable the "vp" feature.
+ */
 pub struct TimerUnit<const BASE_ADDRESS: usize>;
 
 impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
@@ -52,6 +57,9 @@ impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
         return read_u32(BASE_ADDRESS + Self::TIMER_COUNTER_REG_OFFSET);
     }
 
+    /**
+     * Debug only method used to peek into the timer's control register.
+     */
     #[inline]
     #[cfg(debug_assertions)]
     pub fn get_ctrl_reg() -> u32 {
@@ -59,7 +67,11 @@ impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
     }
 }
 
+///Type alias that should be used to interface timer 0.
 pub type Timer0 = TimerUnit::<TIMER0_ADDR>;
+///Type alias that should be used to interface timer 1.
 pub type Timer1 = TimerUnit::<TIMER1_ADDR>;
+///Type alias that should be used to interface timer 2.
 pub type Timer2 = TimerUnit::<TIMER2_ADDR>;
+///Type alias that should be used to interface timer 3.
 pub type Timer3 = TimerUnit::<TIMER3_ADDR>;

--- a/examples/headsail-bsp/src/timer_unit.rs
+++ b/examples/headsail-bsp/src/timer_unit.rs
@@ -11,46 +11,52 @@ use crate::{mmap::TIMER0_ADDR, read_u32, write_u32};
 
 use bit_field::BitField;
 
-const TIMER0_CTRL_REG_OFFSET: usize = 0x0;
-const TIMER0_COUNTER_REG_OFFSET: usize = 0x8;
-const TIMER0_ENABLE_BIT: usize = 0b0;
+pub struct TimerUnit<const BASE_ADDRESS: usize>;
 
-/**
- * Enables the timer (starts counting).
- */
-#[inline]
-pub fn timer0_enable() {
-    // Read register
-    let mut reg = read_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET);
-    // Make enable bit 1
-    reg.set_bit(TIMER0_ENABLE_BIT, true);
-    // Write register back
-    write_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET, reg);
+impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
+    const TIMER_CTRL_REG_OFFSET: usize = 0x0;
+    const TIMER_COUNTER_REG_OFFSET: usize = 0x8;
+    const TIMER_ENABLE_BIT: usize = 0b0;
+
+    /**
+     * Enables the timer (starts counting).
+     */
+    #[inline]
+    pub fn enable() {
+        // Read register
+        let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
+        // Make enable bit 1
+        reg.set_bit(Self::TIMER_ENABLE_BIT, true);
+        // Write register back
+        write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
+    }
+
+    /**
+     * Disables the timer (stops counting).
+     */
+    #[inline]
+    pub fn disable() {
+        // Read register
+        let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
+        // Write 0 to bit 0 but leave all other bits untouched
+        reg.set_bit(Self::TIMER_ENABLE_BIT as usize, false);
+        // Write register back
+        write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
+    }
+
+    /**
+     * Returns the timer counter (tick value).
+     */
+    #[inline]
+    pub fn get_count() -> u32 {
+        return read_u32(BASE_ADDRESS + Self::TIMER_COUNTER_REG_OFFSET);
+    }
+
+    #[inline]
+    #[cfg(debug_assertions)]
+    pub fn get_ctrl_reg() -> u32 {
+        return read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
+    }
 }
 
-/**
- * Disables the timer (stops counting).
- */
-#[inline]
-pub fn timer0_disable() {
-    // Read register
-    let mut reg = read_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET);
-    // Write 0 to bit 0 but leave all other bits untouched
-    reg.set_bit(TIMER0_ENABLE_BIT as usize, false);
-    // Write register back
-    write_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET, reg);
-}
-
-/**
- * Returns the timer counter (tick value).
- */
-#[inline]
-pub fn timer0_get_count() -> u32 {
-    return read_u32(TIMER0_ADDR + TIMER0_COUNTER_REG_OFFSET);
-}
-
-#[inline]
-#[cfg(debug_assertions)]
-pub fn timer0_get_ctrl_reg() -> u32 {
-    return read_u32(TIMER0_ADDR + TIMER0_CTRL_REG_OFFSET);
-}
+pub type Timer0 = TimerUnit::<TIMER0_ADDR>;

--- a/examples/headsail-bsp/src/timer_unit.rs
+++ b/examples/headsail-bsp/src/timer_unit.rs
@@ -12,13 +12,13 @@ use crate::{mmap::*, read_u32, write_u32};
 use bit_field::BitField;
 
 /**
- * Relocatable driver for the PULP Timer Unit IP. The generic represents the 
- * base address for the timer. This driver is for the Renode Virtual Prototype 
+ * Relocatable driver for the PULP Timer Unit IP. The generic represents the
+ * base address for the timer. This driver is for the Renode Virtual Prototype
  * only. For the ASIC driver, disable the "vp" feature.
  */
 pub struct TimerUnit<const BASE_ADDRESS: usize>;
 
-impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
+impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS> {
     const TIMER_CTRL_REG_OFFSET: usize = 0x0;
     const TIMER_COUNTER_REG_OFFSET: usize = 0x8;
     const TIMER_ENABLE_BIT: usize = 0b0;
@@ -28,11 +28,9 @@ impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
      */
     #[inline]
     pub fn enable() {
-        // Read register
         let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
         // Make enable bit 1
         reg.set_bit(Self::TIMER_ENABLE_BIT, true);
-        // Write register back
         write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
     }
 
@@ -41,11 +39,9 @@ impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
      */
     #[inline]
     pub fn disable() {
-        // Read register
         let mut reg = read_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET);
         // Write 0 to bit 0 but leave all other bits untouched
         reg.set_bit(Self::TIMER_ENABLE_BIT as usize, false);
-        // Write register back
         write_u32(BASE_ADDRESS + Self::TIMER_CTRL_REG_OFFSET, reg);
     }
 
@@ -68,10 +64,10 @@ impl<const BASE_ADDRESS: usize> TimerUnit<BASE_ADDRESS>{
 }
 
 ///Type alias that should be used to interface timer 0.
-pub type Timer0 = TimerUnit::<TIMER0_ADDR>;
+pub type Timer0 = TimerUnit<TIMER0_ADDR>;
 ///Type alias that should be used to interface timer 1.
-pub type Timer1 = TimerUnit::<TIMER1_ADDR>;
+pub type Timer1 = TimerUnit<TIMER1_ADDR>;
 ///Type alias that should be used to interface timer 2.
-pub type Timer2 = TimerUnit::<TIMER2_ADDR>;
+pub type Timer2 = TimerUnit<TIMER2_ADDR>;
 ///Type alias that should be used to interface timer 3.
-pub type Timer3 = TimerUnit::<TIMER3_ADDR>;
+pub type Timer3 = TimerUnit<TIMER3_ADDR>;


### PR DESCRIPTION
This pull request adds relocatable drivers for the timers of the HPC subsystem. The drivers have been implemented as structs with a generic constant.
Moreover, the base addresses for timers 1 to 3 have been added to the mmap.rs file.
Finally, new documentation has been added and existing documentation has been rewritten in a Rust doc-friendly way.