### PR TITLE
Adds ability to read from uart to heap

### DIFF
--- a/examples/headsail-bsp/Cargo.toml
+++ b/examples/headsail-bsp/Cargo.toml
@@ -43,6 +43,11 @@ path = "examples/uart0.rs"
 required-features = ["rt"]
 
 [[example]]
+name = "uart0-read"
+path = "examples/uart0-read.rs"
+required-features = ["alloc", "rt", "sdram"]
+
+[[example]]
 name = "sprintln"
 path = "examples/sprintln.rs"
 required-features = ["rt"]

--- a/examples/headsail-bsp/examples/uart0-read.rs
+++ b/examples/headsail-bsp/examples/uart0-read.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+use headsail_bsp::{init_alloc, rt::entry, sprint, sprintln, uart::uart_read_to_heap};
+
+#[entry]
+fn main() -> ! {
+    sprintln!("Connect to uart with: screen /tmp/uart0");
+    init_alloc();
+    loop {
+        let res = uart_read_to_heap(8);
+        for x in res {
+            if x != 0 {
+                sprint!("{:x} ", x)
+            }
+        }
+    }
+}

--- a/examples/headsail-bsp/src/mmap.rs
+++ b/examples/headsail-bsp/src/mmap.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "hpc")]
-pub(crate) const UART0_ADDR: usize = 0xFFF00000;
-#[cfg(not(feature = "hpc"))]
 pub(crate) const UART0_ADDR: usize = 0xFFF00000;
 // NOTE: (20240614 vaino-waltteri.granat@tuni.fi) This applies to renode NS16550 uart, but might not apply to headsail ASIC
 pub(crate) const UART_DATA_READY_OFFSET: usize = 5;

--- a/examples/headsail-bsp/src/mmap.rs
+++ b/examples/headsail-bsp/src/mmap.rs
@@ -1,4 +1,9 @@
+#[cfg(feature = "hpc")]
 pub(crate) const UART0_ADDR: usize = 0xFFF00000;
+#[cfg(not(feature = "hpc"))]
+pub(crate) const UART0_ADDR: usize = 0xFFF00000;
+// NOTE: (20240614 vaino-waltteri.granat@tuni.fi) This applies to renode NS16550 uart, but might not apply to headsail ASIC
+pub(crate) const UART_DATA_READY_OFFSET: usize = 5;
 pub(crate) const TIMER0_ADDR: usize = 0x5_0000;
 pub(crate) const TIMER1_ADDR: usize = 0x5_0010;
 pub(crate) const TIMER2_ADDR: usize = 0x5_0020;

--- a/examples/headsail-bsp/src/uart.rs
+++ b/examples/headsail-bsp/src/uart.rs
@@ -1,4 +1,10 @@
-use crate::{mmap::UART0_ADDR, write_u8};
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+use crate::{mmap::UART0_ADDR, mmap::UART_DATA_READY_OFFSET, read_u8, write_u8};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 #[inline]
 pub fn uart_write(s: &str) {
@@ -11,4 +17,27 @@ pub fn uart_write(s: &str) {
 pub fn putc(c: u8) {
     // Safety: we don't know if u8 writes work for all target architectures
     unsafe { write_u8(UART0_ADDR, c) };
+}
+
+#[inline]
+pub fn getc() -> Option<u8> {
+    let data_ready = unsafe { read_u8(UART0_ADDR + UART_DATA_READY_OFFSET) };
+    if data_ready & 1 == 0 {
+        None
+    } else {
+        let byte = unsafe { read_u8(UART0_ADDR) };
+        Some(byte)
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub fn uart_read_to_heap(bytes: usize) -> Vec<u8> {
+    let mut result = Vec::with_capacity(bytes);
+    while result.len() < bytes {
+        match getc() {
+            Some(c) => result.push(c),
+            None => (),
+        }
+    }
+    result
 }

--- a/examples/headsail-bsp/src/uart.rs
+++ b/examples/headsail-bsp/src/uart.rs
@@ -1,8 +1,7 @@
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
 use crate::{mmap::UART0_ADDR, mmap::UART_DATA_READY_OFFSET, read_u8, write_u8};
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 


### PR DESCRIPTION
In preparation to DLA inputs being sent to HPC over UART, we need to have ability read UART in headsail-bsp. PR adds basic functionality for reading known number of bytes from UART into heap.