### PR TITLE
Adds support for HPC external bit in DLA

### DIFF
--- a/examples/headsail-bsp/src/alloc/mod.rs
+++ b/examples/headsail-bsp/src/alloc/mod.rs
@@ -1,5 +1,8 @@
 use good_memory_allocator::SpinLockedAllocator;
 
+#[cfg(feature = "hpc")]
+const HEAP_START: usize = 0x130000000;
+#[cfg(not(feature = "hpc"))]
 const HEAP_START: usize = 0x30000000;
 const HEAP_SIZE: usize = 0x10000000;
 

--- a/examples/hpc/dla-driver/Cargo.toml
+++ b/examples/hpc/dla-driver/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 vp = []
+hpc = []
 
 [dependencies]
 panic-halt = "0.2.0"

--- a/examples/hpc/dla-driver/src/mmap.rs
+++ b/examples/hpc/dla-driver/src/mmap.rs
@@ -1,6 +1,13 @@
-pub(crate) const UART0_ADDR: usize = 0xFFF00000;
+#[cfg(feature = "hpc")]
+pub const DLA0_ADDR: usize = 0x1FF700000;
+#[cfg(not(feature = "hpc"))]
 pub const DLA0_ADDR: usize = 0xFF700000;
+
+#[cfg(feature = "hpc")]
+pub const MEMORY_BANK_BASE_ADDR: usize = 0x170000000;
+#[cfg(not(feature = "hpc"))]
 pub const MEMORY_BANK_BASE_ADDR: usize = 0x70000000;
+
 pub const MEMORY_BANK_SIZE: usize = 0x8000;
 pub const MEMORY_BANK_0_OFFSET: usize = 0x00000;
 pub const MEMORY_BANK_1_OFFSET: usize = 0x08000;
@@ -18,8 +25,6 @@ pub const MEMORY_BANK_12_OFFSET: usize = 0x60000;
 pub const MEMORY_BANK_13_OFFSET: usize = 0x68000;
 pub const MEMORY_BANK_14_OFFSET: usize = 0x70000;
 pub const MEMORY_BANK_15_OFFSET: usize = 0x78000;
-
-pub(crate) const DLA_BASE_ADDR: usize = 0x1000;
 
 pub(crate) const DLA_STATUS_ADDR: usize = 0x0;
 pub(crate) const DLA_BUF_DONE_OFFSET: usize = 0x0;

--- a/vp/devel/python_peripherals/DLA.py
+++ b/vp/devel/python_peripherals/DLA.py
@@ -1267,7 +1267,7 @@ class DlaMac:
 def write(request, dla):
     self.NoisyLog("Absolute: 0x%x  Writing request offset: %s at 0x%x, value 0x%x" % (request.absolute, str(request.type), request.offset, request.value))
     print("Absolute: 0x%x  Writing request offset: %s at 0x%x, value 0x%x" % (request.absolute, str(request.type), request.offset, request.value))
-    request.absolute = request.absolute & 0xFFFFFFFF
+    request.absolute = request.absolute & 0xFFFFFFFF # Normalize address to global address space by removing possible HPC external bit
     if int(request.absolute) >= DLA_ADDR:
         dla.set_register(request.offset, 0, 32, request.value, preserve_register=False)
     else:
@@ -1276,14 +1276,14 @@ def write(request, dla):
 
 def read(request, dla):
     original_absolute = request.absolute # Handle non-global address space addressing
-    request.absolute = request.absolute & 0xFFFFFFFF
+    request.absolute = request.absolute & 0xFFFFFFFF # Normalize address to global address space by removing possible HPC external bit
     if int(request.absolute) >= DLA_ADDR:
         request.value = dla.get_register(request.offset, 0, 32)
     else:
         tmp = dla.handle_bank_read(request)
         request.value = tmp
 
-    request.absolute = original_absolute
+    request.absolute = original_absolute # Answer to original address
     self.NoisyLog("Reading request: %s at 0x%x, value 0x%x" % (str(request.type), request.absolute, request.value))
     print("Absolute: 0x%x  Reading request offset: %s at 0x%x, value 0x%x" % (request.absolute, str(request.type), request.offset, request.value))
 

--- a/vp/devel/python_peripherals/DLA.py
+++ b/vp/devel/python_peripherals/DLA.py
@@ -1267,6 +1267,7 @@ class DlaMac:
 def write(request, dla):
     self.NoisyLog("Absolute: 0x%x  Writing request offset: %s at 0x%x, value 0x%x" % (request.absolute, str(request.type), request.offset, request.value))
     print("Absolute: 0x%x  Writing request offset: %s at 0x%x, value 0x%x" % (request.absolute, str(request.type), request.offset, request.value))
+    request.absolute = request.absolute & 0xFFFFFFFF
     if int(request.absolute) >= DLA_ADDR:
         dla.set_register(request.offset, 0, 32, request.value, preserve_register=False)
     else:
@@ -1274,12 +1275,15 @@ def write(request, dla):
     dla.process()
 
 def read(request, dla):
+    original_absolute = request.absolute # Handle non-global address space addressing
+    request.absolute = request.absolute & 0xFFFFFFFF
     if int(request.absolute) >= DLA_ADDR:
         request.value = dla.get_register(request.offset, 0, 32)
     else:
         tmp = dla.handle_bank_read(request)
         request.value = tmp
 
+    request.absolute = original_absolute
     self.NoisyLog("Reading request: %s at 0x%x, value 0x%x" % (str(request.type), request.absolute, request.value))
     print("Absolute: 0x%x  Reading request offset: %s at 0x%x, value 0x%x" % (request.absolute, str(request.type), request.offset, request.value))
 


### PR DESCRIPTION
In https://github.com/soc-hub-fi/headsail-vp/pull/41 it was agreed to leave DLA broken to retain a somewhat manageable scope for the PR. This PR adds HPC external bit handling to the DLA.py and dla-driver. The conv2d validation is not fixed in this PR.