### PR TITLE
Switch SysCtrl architecture & fix several minor errors reported by tools

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install requirements
-      run: rustup target add riscv64imac-unknown-none-elf riscv32imc-unknown-none-elf
+      run: rustup target add riscv64imac-unknown-none-elf riscv32im-unknown-none-elf
 
     - name: Run linter
       working-directory: ./examples/headsail-bsp
@@ -170,10 +170,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install requirements
-      run: rustup target add riscv64imac-unknown-none-elf riscv32imc-unknown-none-elf
+      run: rustup target add riscv64imac-unknown-none-elf riscv32im-unknown-none-elf
     - name: Build FFI without RT on SysCtrl
       working-directory: ./examples/headsail-bsp-ffi
-      run: cargo build --target=riscv32imc-unknown-none-elf -Fpanic-uart
+      run: cargo build --target=riscv32im-unknown-none-elf -Fpanic-uart
     - name: Build FFI without RT on HPC
       working-directory: ./examples/headsail-bsp-ffi
       run: cargo build --target=riscv64imac-unknown-none-elf -Fpanic-uart

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Rust <https://rustup.rs/>
 2. Codegen backend for target cores
     * `rustup target add riscv64imac-unknown-none-elf`
-    * `rustup target add riscv32imc-unknown-none-elf`
+    * `rustup target add riscv32im-unknown-none-elf`
 
 ### Run UART example
 

--- a/examples/headsail-bsp-ffi/Justfile
+++ b/examples/headsail-bsp-ffi/Justfile
@@ -1,5 +1,5 @@
 build-sysctrl:
-    cargo build --target=riscv32imc-unknown-none-elf -Fpanic-uart --release
+    cargo build --target=riscv32im-unknown-none-elf -Fpanic-uart --release
 
 build-hpc:
     cargo build --target=riscv64imac-unknown-none-elf -Fpanic-uart --release

--- a/examples/headsail-bsp/.cargo/config.toml
+++ b/examples/headsail-bsp/.cargo/config.toml
@@ -3,7 +3,6 @@ runner = "../../scripts/run_on_hpc.sh"
 linker = "riscv64-unknown-elf-ld"
 rustflags = ["-C", "link-arg=-Tmem_hpc.x", "-C", "link-arg=-Tlink.x"]
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32im-unknown-none-elf]
 runner = "../../scripts/run_on_sysctrl.sh"
 rustflags = ["-C", "link-arg=-Tmem_sysctrl.x", "-C", "link-arg=-Tlink.x"]
-

--- a/examples/headsail-bsp/README.md
+++ b/examples/headsail-bsp/README.md
@@ -9,7 +9,7 @@ Minimal BSP for testing the virtual prototype.
 RUSTFLAGS="-C link-arg=-Tmem_hpc.x -C link-arg=-Tlink.x" cargo build --examples -Fpanic-uart -Fhpc-rt -Falloc --target riscv64imac-unknown-none-elf
 
 # SysCtrl
-RUSTFLAGS="-C link-arg=-Tmem_sysctrl.x -C link-arg=-Tlink.x" cargo build --examples -Fpanic-uart -Fsysctrl-rt --target riscv32imc-unknown-none-elf
+RUSTFLAGS="-C link-arg=-Tmem_sysctrl.x -C link-arg=-Tlink.x" cargo build --examples -Fpanic-uart -Fsysctrl-rt --target riscv32im-unknown-none-elf
 ```
 
 ## Running examples

--- a/examples/sysctrl/.cargo/config.toml
+++ b/examples/sysctrl/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32im-unknown-none-elf"

--- a/examples/sysctrl/Cargo.toml
+++ b/examples/sysctrl/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["hello-sysctrl"]
+resolver = "2"

--- a/examples/sysctrl/hello-sysctrl/.cargo/config.toml
+++ b/examples/sysctrl/hello-sysctrl/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
-target = "riscv32imc-unknown-none-elf"
+target = "riscv32im-unknown-none-elf"
 
-[target.riscv32imc-unknown-none-elf]
+[target.riscv32im-unknown-none-elf]
 runner = "../../../scripts/run_on_sysctrl.sh"
 rustflags = ["-C", "link-arg=-Tmem_sysctrl.x", "-C", "link-arg=-Tlink.x"]

--- a/scripts/resc/1_hpc.resc
+++ b/scripts/resc/1_hpc.resc
@@ -1,6 +1,6 @@
 include $ORIGIN/0_mach_create.resc
 
-# Suspend all cores except for core #0
+# Suspend all cores except for HPC core #0
 sysbus.cpu_hpc1 IsHalted True
 sysbus.cpu_hpc2 IsHalted True
 sysbus.cpu_hpc3 IsHalted True

--- a/scripts/resc/1_sysctrl.resc
+++ b/scripts/resc/1_sysctrl.resc
@@ -1,3 +1,9 @@
 include $ORIGIN/0_mach_create.resc
 
+# Suspend all cores except for SysCtrl
+sysbus.cpu_hpc0 IsHalted True
+sysbus.cpu_hpc1 IsHalted True
+sysbus.cpu_hpc2 IsHalted True
+sysbus.cpu_hpc3 IsHalted True
+
 machine StartGdbServer 3333 true sysbus.cpu_sysctrl

--- a/vp/devel/headsail.repl
+++ b/vp/devel/headsail.repl
@@ -20,7 +20,7 @@ cpu_hpc3: CPU.RiscV64 @ sysbus
 
 cpu_sysctrl: CPU.IbexRiscV32 @ sysbus
     // CPU ISA is actually rv32em but SW & VP support for that is sketchy
-    cpuType: "rv32imc"
+    cpuType: "rv32im"
     timeProvider: empty
     allowUnalignedAccesses: false
 


### PR DESCRIPTION
SysCtrl is in fact RV32EM, not RV32IMC. Renode supports RV32IM which is closer to EM than EMC so we'll use that one for this VP.

Also fixes some minor errors reported by cargo & Renode.