### PR TITLE
Adds Tensors objects to DLA

### DIFF
--- a/examples/hpc/dla-driver/Cargo.toml
+++ b/examples/hpc/dla-driver/Cargo.toml
@@ -18,6 +18,7 @@ headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = [
 
 
 rand = { version = "0.8.3", features = ["small_rng"], default-features = false }
+ndarray = { version = "0.15.6", default-features = false }
 
 [[example]]
 name = "mac_benchmark"

--- a/examples/hpc/dla-driver/src/tensor3.rs
+++ b/examples/hpc/dla-driver/src/tensor3.rs
@@ -15,7 +15,7 @@ pub enum Order3 {
 }
 
 impl Order3 {
-    fn into_position(&self) -> [usize; 3] {
+    fn into_position(self) -> [usize; 3] {
         match self {
             Order3::CHW => [0, 1, 2],
             Order3::CWH => [0, 2, 1],

--- a/examples/hpc/dla-driver/src/tensor3.rs
+++ b/examples/hpc/dla-driver/src/tensor3.rs
@@ -1,0 +1,248 @@
+#![no_std]
+#![no_main]
+
+use alloc::vec::*;
+use headsail_bsp::ufmt::uDisplay;
+use headsail_bsp::{sprint, sprintln};
+use ndarray::{Array, Array3};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Order3 {
+    CHW,
+    CWH,
+    HWC,
+    HCW,
+    WHC,
+    WCH,
+}
+
+impl From<Order3> for [usize; 3] {
+    fn from(order: Order3) -> Self {
+        match order {
+            Order3::CHW => [0, 1, 2],
+            Order3::CWH => [0, 2, 1],
+            Order3::HWC => [1, 2, 0],
+            Order3::HCW => [1, 0, 2],
+            Order3::WHC => [2, 1, 0],
+            Order3::WCH => [2, 0, 1],
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Tensor3<T> {
+    data: Array3<T>,
+    pub channels: usize,
+    pub height: usize,
+    pub width: usize,
+    order: Order3,
+}
+
+impl<T: Clone + uDisplay> Tensor3<T> {
+    // Creates a new Tensor3 with the specified dimensions, initial value, and order
+    pub fn new(
+        channels: usize,
+        height: usize,
+        width: usize,
+        initial_value: T,
+        order: Order3,
+    ) -> Self {
+        let data = Array::from_elem((channels, height, width), initial_value);
+        Tensor3 {
+            data,
+            channels,
+            height,
+            width,
+            order,
+        }
+    }
+
+    /// Creates a new Tensor3 from a data buffer with the specified order
+    pub fn from_array3(data: Array3<T>, order: Order3) -> Self {
+        let shape = data.shape();
+
+        let dim_order: [usize; 3] = order.into();
+        let channels = shape[dim_order.iter().position(|&r| r == 0).unwrap()];
+        let height = shape[dim_order.iter().position(|&r| r == 1).unwrap()];
+        let width = shape[dim_order.iter().position(|&r| r == 2).unwrap()];
+
+        Tensor3 {
+            data,
+            channels,
+            height,
+            width,
+            order,
+        }
+    }
+
+    /// Creates a new Tensor3 from a data buffer with the specified order
+    pub fn from_data_buffer(
+        channels: usize,
+        height: usize,
+        width: usize,
+        data_buffer: Vec<T>,
+        order: Order3,
+    ) -> Result<Self, &'static str> {
+        if data_buffer.len() != channels * height * width {
+            return Err("Data buffer size does not match specified dimensions");
+        }
+
+        let standard_shape = [channels, height, width];
+        let dim_order: [usize; 3] = order.into();
+        let fst = standard_shape[dim_order[0]];
+        let snd = standard_shape[dim_order[1]];
+        let thd = standard_shape[dim_order[2]];
+
+        let data = Array::from_shape_vec((fst, snd, thd), data_buffer)
+            .map_err(|_| "Failed to create array from data buffer")?;
+
+        Ok(Tensor3 {
+            data,
+            channels,
+            height,
+            width,
+            order,
+        })
+    }
+
+    /// Get the number of element in ndarray
+    pub fn get_size(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Matches order field value to height, width and channels parameters
+    fn get_dimension_order_values(&self, order: Option<Order3>) -> [usize; 3] {
+        let mut out = [0; 3];
+
+        // Use self value if no order was given
+        let order: [usize; 3] = match order {
+            Some(order) => order.into(),
+            None => self.order.into(),
+        };
+
+        for (i, x) in order.into_iter().enumerate() {
+            let param = match x {
+                0 => self.channels,
+                1 => self.height,
+                2 => self.width,
+                _ => unimplemented!(),
+            };
+            out[i] = param;
+        }
+        out
+    }
+
+    /// Returns a reference to the element at the specified position
+    pub fn get(&self, channel: usize, row: usize, col: usize) -> Option<&T> {
+        self.data.get((channel, row, col))
+    }
+
+    /// Returns a mutable reference to the element at the specified position
+    pub fn get_mut(&mut self, channel: usize, row: usize, col: usize) -> Option<&mut T> {
+        self.data.get_mut((channel, row, col))
+    }
+
+    /// Sets the element at the specified position
+    pub fn set(
+        &mut self,
+        channel: usize,
+        row: usize,
+        col: usize,
+        value: T,
+    ) -> Result<(), &'static str> {
+        if let Some(elem) = self.data.get_mut((channel, row, col)) {
+            *elem = value;
+            Ok(())
+        } else {
+            Err("Index out of bounds")
+        }
+    }
+
+    /// Returns the dimensions of the array
+    pub fn dimensions(&self) -> (usize, usize, usize) {
+        (self.channels, self.height, self.width)
+    }
+
+    /// Gets the current order of the array
+    pub fn order(&self) -> Order3 {
+        self.order
+    }
+
+    /// Sets a new order for the array
+    pub fn transmute(&mut self, order: Order3) {
+        // Early return if already in order
+        if self.order == order {
+            return;
+        }
+
+        if self.order == Order3::CHW {
+            // Transmute to target order
+            let new_order: [usize; 3] = order.into();
+            self.data = self.data.clone().permuted_axes(new_order);
+            self.order = order;
+            return;
+        }
+
+        // Transmute to standard order
+        let std_order: [usize; 3] = self.order.into();
+        let std = self.data.clone().permuted_axes(std_order);
+
+        // Transmute to target order
+        let new_order: [usize; 3] = order.into();
+        self.data = std.permuted_axes(new_order);
+        self.order = order;
+    }
+
+    /// Converts the internal buffer to CHW order
+    fn to_chw_buffer(&self) -> Vec<T> {
+        self.to_buffer_with_order(Order3::CHW)
+    }
+
+    /// Converts the 3D array to a linear buffer according to the current order
+    pub fn to_buffer(&self) -> Vec<T> {
+        let mut buffer = Vec::with_capacity(self.channels * self.height * self.width);
+        for x in Array::from_iter(self.data.iter().cloned()) {
+            buffer.push(x)
+        }
+        buffer
+    }
+
+    /// Converts the 3D array to a linear buffer according to the specified order
+    pub fn to_buffer_with_order(&self, order: Order3) -> Vec<T> {
+        // If order is correct no need to permute
+        if order == self.order {
+            return self.to_buffer();
+        }
+
+        let mut data = self.clone();
+        data.transmute(order);
+        data.to_buffer()
+    }
+
+    /// Prints tensor in current order
+    pub fn print_tensor(&self) {
+        sprintln!("Channels: {}", self.channels);
+        sprintln!("Height: {}", self.height);
+        sprintln!("Width: {}", self.width);
+        let chw_buffer = self.to_chw_buffer(); // Use common format
+        let data = Array::from_shape_vec((self.channels, self.height, self.width), chw_buffer)
+            .expect("Failed to reshape buffer to CHW order");
+
+        let dim_order: [usize; 3] = self.order.into();
+        let dim_order_values = self.get_dimension_order_values(None);
+
+        for i in 0..dim_order_values[0] {
+            for j in 0..dim_order_values[1] {
+                for k in 0..dim_order_values[2] {
+                    // Match iterators i,j,k to current ordering scheme to find index data in standard CHW order
+                    let c = [i, j, k][dim_order.iter().position(|&r| r == 0).unwrap()];
+                    let h = [i, j, k][dim_order.iter().position(|&r| r == 1).unwrap()];
+                    let w = [i, j, k][dim_order.iter().position(|&r| r == 2).unwrap()];
+                    sprint!("{} ", data[(c, h, w)]);
+                }
+                sprintln!("")
+            }
+            sprintln!("")
+        }
+    }
+}

--- a/examples/hpc/dla-driver/src/tensor3.rs
+++ b/examples/hpc/dla-driver/src/tensor3.rs
@@ -48,17 +48,17 @@ impl<T: Clone> Tensor3<T> {
 
     pub fn channels(&self) -> usize {
         let dim_order: [usize; 3] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 0).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 0).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
     pub fn height(&self) -> usize {
         let dim_order: [usize; 3] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 1).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 1).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
     pub fn width(&self) -> usize {
         let dim_order: [usize; 3] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 2).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 2).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
 

--- a/examples/hpc/dla-driver/src/tensor4.rs
+++ b/examples/hpc/dla-driver/src/tensor4.rs
@@ -33,7 +33,7 @@ pub enum Order4 {
 }
 
 impl Order4 {
-    fn into_position(&self) -> [usize; 4] {
+    fn into_position(self) -> [usize; 4] {
         match self {
             Order4::KCHW => [0, 1, 2, 3],
             Order4::KCWH => [0, 1, 3, 2],

--- a/examples/hpc/dla-driver/src/tensor4.rs
+++ b/examples/hpc/dla-driver/src/tensor4.rs
@@ -84,24 +84,24 @@ impl<T: Clone> Tensor4<T> {
     }
     pub fn kernels(&self) -> usize {
         let dim_order: [usize; 4] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 0).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 0).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
     pub fn channels(&self) -> usize {
         let dim_order: [usize; 4] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 1).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 1).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
 
     pub fn height(&self) -> usize {
         let dim_order: [usize; 4] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 2).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 2).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
 
     pub fn width(&self) -> usize {
         let dim_order: [usize; 4] = self.order.into_position();
-        let position = dim_order.iter().position(|&r| r == 3).unwrap();
+        let position = unsafe { dim_order.iter().position(|&r| r == 3).unwrap_unchecked() };
         self.data.raw_dim()[position]
     }
 
@@ -130,10 +130,14 @@ impl<T: Clone> Tensor4<T> {
 
         let standard_shape = [kernels, channels, height, width];
         let dim_order: [usize; 4] = order.into_position();
-        let kernels_ordered = standard_shape[dim_order.iter().position(|&r| r == 0).unwrap()];
-        let channels_ordered = standard_shape[dim_order.iter().position(|&r| r == 1).unwrap()];
-        let height_ordered = standard_shape[dim_order.iter().position(|&r| r == 2).unwrap()];
-        let width_ordered = standard_shape[dim_order.iter().position(|&r| r == 3).unwrap()];
+        let kernels_ordered =
+            standard_shape[unsafe { dim_order.iter().position(|&r| r == 0).unwrap_unchecked() }];
+        let channels_ordered =
+            standard_shape[unsafe { dim_order.iter().position(|&r| r == 1).unwrap_unchecked() }];
+        let height_ordered =
+            standard_shape[unsafe { dim_order.iter().position(|&r| r == 2).unwrap_unchecked() }];
+        let width_ordered =
+            standard_shape[unsafe { dim_order.iter().position(|&r| r == 3).unwrap_unchecked() }];
 
         let data = Array::from_shape_vec(
             (

--- a/examples/hpc/dla-driver/src/tensor4.rs
+++ b/examples/hpc/dla-driver/src/tensor4.rs
@@ -1,0 +1,311 @@
+#![no_std]
+#![no_main]
+
+use alloc::vec::*;
+use headsail_bsp::ufmt::uDisplay;
+use headsail_bsp::{sprint, sprintln};
+use ndarray::{Array, Array4};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Order4 {
+    KCHW,
+    KCWH,
+    KHWC,
+    KHCW,
+    KWHC,
+    KWCH,
+    CKHW,
+    CKWH,
+    CHWK,
+    CHKW,
+    CWKH,
+    CWHK,
+    HKCW,
+    HKWC,
+    HCKW,
+    HCWK,
+    HWCK,
+    HWKC,
+    WKCH,
+    WKHC,
+    WCKH,
+    WCHK,
+    WHCK,
+    WHKC,
+}
+
+impl From<Order4> for [usize; 4] {
+    fn from(order: Order4) -> Self {
+        match order {
+            Order4::KCHW => [0, 1, 2, 3],
+            Order4::KCWH => [0, 1, 3, 2],
+            Order4::KHWC => [0, 2, 3, 1],
+            Order4::KHCW => [0, 2, 1, 3],
+            Order4::KWCH => [0, 3, 1, 2],
+            Order4::KWHC => [0, 3, 2, 1],
+            Order4::CKHW => [1, 0, 2, 3],
+            Order4::CKWH => [1, 0, 3, 2],
+            Order4::CHWK => [1, 2, 0, 3],
+            Order4::CHKW => [1, 2, 3, 0],
+            Order4::CWKH => [1, 3, 0, 2],
+            Order4::CWHK => [1, 3, 2, 0],
+            Order4::HKCW => [2, 0, 1, 3],
+            Order4::HKWC => [2, 0, 3, 1],
+            Order4::HCKW => [2, 1, 0, 3],
+            Order4::HCWK => [2, 1, 3, 0],
+            Order4::HWCK => [2, 3, 0, 1],
+            Order4::HWKC => [2, 3, 1, 0],
+            Order4::WKCH => [3, 0, 1, 2],
+            Order4::WKHC => [3, 0, 2, 1],
+            Order4::WCKH => [3, 1, 0, 2],
+            Order4::WCHK => [3, 1, 2, 0],
+            Order4::WHCK => [3, 2, 0, 1],
+            Order4::WHKC => [3, 2, 1, 0],
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Tensor4<T> {
+    data: Array4<T>,
+    pub channels: usize,
+    pub kernels: usize,
+    pub height: usize,
+    pub width: usize,
+    order: Order4,
+}
+
+impl<T: Clone + uDisplay> Tensor4<T> {
+    // Creates a new Tensor4 with the specified dimensions, initial value, and order
+    pub fn new(
+        kernels: usize,
+        channels: usize,
+        height: usize,
+        width: usize,
+        initial_value: T,
+        order: Order4,
+    ) -> Self {
+        let data = Array::from_elem((kernels, channels, height, width), initial_value);
+        Tensor4 {
+            data,
+            kernels,
+            channels,
+            height,
+            width,
+            order,
+        }
+    }
+
+    /// Creates a new Tensor4 from a data buffer with the specified order
+    pub fn from_array4(data: Array4<T>, order: Order4) -> Self {
+        let shape = data.shape();
+
+        let dim_order: [usize; 4] = order.into();
+        let kernels = shape[dim_order.iter().position(|&r| r == 0).unwrap()];
+        let channels = shape[dim_order.iter().position(|&r| r == 1).unwrap()];
+        let height = shape[dim_order.iter().position(|&r| r == 2).unwrap()];
+        let width = shape[dim_order.iter().position(|&r| r == 3).unwrap()];
+
+        Tensor4 {
+            data,
+            kernels,
+            channels,
+            height,
+            width,
+            order,
+        }
+    }
+
+    /// Get the number of element in ndarray
+    pub fn get_size(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Creates a new Tensor4 from a data buffer with the specified order
+    pub fn from_data_buffer(
+        kernels: usize,
+        channels: usize,
+        height: usize,
+        width: usize,
+        data_buffer: Vec<T>,
+        order: Order4,
+    ) -> Result<Self, &'static str> {
+        if data_buffer.len() != kernels * channels * height * width {
+            return Err("Data buffer size does not match specified dimensions");
+        }
+
+        let standard_shape = [kernels, channels, height, width];
+        let dim_order: [usize; 4] = order.into();
+        let kernels_ordered = standard_shape[dim_order.iter().position(|&r| r == 0).unwrap()];
+        let channels_ordered = standard_shape[dim_order.iter().position(|&r| r == 1).unwrap()];
+        let height_ordered = standard_shape[dim_order.iter().position(|&r| r == 2).unwrap()];
+        let width_ordered = standard_shape[dim_order.iter().position(|&r| r == 3).unwrap()];
+
+        let data = Array::from_shape_vec(
+            (
+                kernels_ordered,
+                channels_ordered,
+                height_ordered,
+                width_ordered,
+            ),
+            data_buffer,
+        )
+        .map_err(|_| "Failed to create array from data buffer")?;
+
+        Ok(Tensor4 {
+            data,
+            kernels,
+            channels,
+            height,
+            width,
+            order,
+        })
+    }
+
+    /// Matches order field value to height, width, channels and kernels parameters
+    fn get_dimension_order_values(&self, order: Option<Order4>) -> [usize; 4] {
+        let mut out = [0; 4];
+
+        // Use self value if no order was given
+        let order: [usize; 4] = match order {
+            Some(order) => order.into(),
+            None => self.order.into(),
+        };
+
+        for (i, x) in order.into_iter().enumerate() {
+            let param = match x {
+                0 => self.kernels,
+                1 => self.channels,
+                2 => self.height,
+                3 => self.width,
+                _ => unimplemented!(),
+            };
+            out[i] = param;
+        }
+        out
+    }
+
+    /// Returns a reference to the element at the specified position
+    pub fn get(&self, kernel: usize, channel: usize, row: usize, col: usize) -> Option<&T> {
+        self.data.get((kernel, channel, row, col))
+    }
+
+    /// Returns a mutable reference to the element at the specified position
+    pub fn get_mut(
+        &mut self,
+        kernel: usize,
+        channel: usize,
+        row: usize,
+        col: usize,
+    ) -> Option<&mut T> {
+        self.data.get_mut((kernel, channel, row, col))
+    }
+
+    /// Sets the element at the specified position
+    pub fn set(
+        &mut self,
+        kernel: usize,
+        channel: usize,
+        row: usize,
+        col: usize,
+        value: T,
+    ) -> Result<(), &'static str> {
+        if let Some(elem) = self.data.get_mut((kernel, channel, row, col)) {
+            *elem = value;
+            Ok(())
+        } else {
+            Err("Index out of bounds")
+        }
+    }
+
+    /// Returns the dimensions of the array
+    pub fn dimensions(&self) -> (usize, usize, usize, usize) {
+        (self.kernels, self.channels, self.height, self.width)
+    }
+
+    /// Sets a new order for the array
+    pub fn transmute(&mut self, order: Order4) {
+        // Early return if already in order
+        if self.order == order {
+            return;
+        }
+
+        if self.order == Order4::KCHW {
+            // Transmute to target order
+            let new_order: [usize; 4] = order.into();
+            self.data = self.data.clone().permuted_axes(new_order);
+            self.order = order;
+            return;
+        }
+
+        // Transmute to standard order
+        let std_order: [usize; 4] = self.order.into();
+        let std = self.data.clone().permuted_axes(std_order);
+
+        // Transmute to target order
+        let new_order: [usize; 4] = order.into();
+        self.data = std.permuted_axes(new_order);
+        self.order = order;
+    }
+
+    /// Transforms data to standard format
+    fn to_kchw_buffer(&self) -> Vec<T> {
+        self.to_buffer_with_order(Order4::KCHW)
+    }
+
+    /// Converts the 4D array to a linear buffer according to the current order
+    pub fn to_buffer(&self) -> Vec<T> {
+        let mut buffer = Vec::with_capacity(self.channels * self.height * self.width);
+        for x in Array::from_iter(self.data.iter().cloned()) {
+            buffer.push(x)
+        }
+        buffer
+    }
+
+    /// Converts the 4D array to a linear buffer according to the specified order
+    pub fn to_buffer_with_order(&self, order: Order4) -> Vec<T> {
+        // If order is correct no need to permute
+        if order == self.order {
+            return self.to_buffer();
+        }
+        let mut data = self.clone();
+        data.transmute(order);
+        data.to_buffer()
+    }
+
+    /// Prints tensor in current order
+    pub fn print_tensor(&self) {
+        // Convert current matrix to standard ordered vector
+        let kchw_buffer = self.to_kchw_buffer();
+        let data = Array::from_shape_vec(
+            (self.kernels, self.channels, self.height, self.width),
+            kchw_buffer,
+        )
+        .expect("Failed to reshape buffer to KCHW order");
+
+        let dim_order_values = self.get_dimension_order_values(None);
+        let dim_order: [usize; 4] = self.order.into();
+
+        // for x in dim_order_values {
+        //     sprint!("{} ", x)
+        // }
+
+        for i in 0..dim_order_values[0] {
+            for j in 0..dim_order_values[1] {
+                for k in 0..dim_order_values[2] {
+                    for l in 0..dim_order_values[3] {
+                        // Match iterators i,j,k to current ordering scheme to find index data in standard KCHW order
+                        let ker = [i, j, k, l][dim_order.iter().position(|&r| r == 0).unwrap()];
+                        let c = [i, j, k, l][dim_order.iter().position(|&r| r == 1).unwrap()];
+                        let h = [i, j, k, l][dim_order.iter().position(|&r| r == 2).unwrap()];
+                        let w = [i, j, k, l][dim_order.iter().position(|&r| r == 3).unwrap()];
+                        sprint!("{} ", data[(ker, c, h, w)]);
+                    }
+                    sprintln!("");
+                }
+                sprintln!("");
+            }
+            sprintln!("");
+        }
+    }
+}


### PR DESCRIPTION
#51 Turned out to be way too big to review, so I split tensor functionality to this PR to reduce the amount of code to review.

Tensors are used to abstract the shape of data. This is useful since DLA expected a different data shape than what TVM does. Also since different models might use other data formats it is sensible to generalize tensors to all possible data shapes.