### PR TITLE
Feat/dla ffi

### DIFF
--- a/examples/hpc-c/cmake/FindDlaDriver.cmake
+++ b/examples/hpc-c/cmake/FindDlaDriver.cmake
@@ -19,15 +19,5 @@ add_custom_command(
     COMMENT "Building dla driver"
 )
 
-add_custom_command(
-    OUTPUT ${DLA_BUILD_DIR_DEBUG}/libdla_driver_ffi.a
-    COMMAND just build-dla-debug
-    WORKING_DIRECTORY ${DLA_PROJECT_DIR}
-    COMMENT "Building dla driver"
-)
-
-
-
 add_custom_target(build_dla DEPENDS ${DLA_BUILD_DIR_RELEASE}/libdla_driver_ffi.a)
-add_custom_target(build_dla-debug DEPENDS ${DLA_BUILD_DIR_DEBUG}/libdla_driver_ffi.a)
 set(DLA_LIBRARIES ${DLA_BUILD_DIR_RELEASE}/libdla_driver_ffi.a)

--- a/examples/hpc-c/cmake/FindDlaDriver.cmake
+++ b/examples/hpc-c/cmake/FindDlaDriver.cmake
@@ -1,0 +1,33 @@
+# Compile & provide library & headers for Headsail DLA Driver
+#
+# DLA_INCLUDE_DIR := directory with BSP headers
+# DLA_LIBRARIES := libraries to be linked
+
+# Add DLA variables
+set(DLA_PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../hpc/dla-driver-ffi)
+set(DLA_TARGET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../hpc/dla-driver-ffi/target)
+set(DLA_INCLUDE_DIR ${DLA_TARGET_DIR}) # Used by CMake
+set(DLA_BUILD_DIR_DEBUG ${DLA_TARGET_DIR}/riscv64imac-unknown-none-elf/debug)
+set(DLA_BUILD_DIR_RELEASE ${DLA_TARGET_DIR}/riscv64imac-unknown-none-elf/release)
+message(DLA_PROJECT_DIR=${DLA_PROJECT_DIR})
+
+# Build DLA
+add_custom_command(
+    OUTPUT ${DLA_BUILD_DIR_RELEASE}/libdla_driver_ffi.a
+    COMMAND just build-dla
+    WORKING_DIRECTORY ${DLA_PROJECT_DIR}
+    COMMENT "Building dla driver"
+)
+
+add_custom_command(
+    OUTPUT ${DLA_BUILD_DIR_DEBUG}/libdla_driver_ffi.a
+    COMMAND just build-dla-debug
+    WORKING_DIRECTORY ${DLA_PROJECT_DIR}
+    COMMENT "Building dla driver"
+)
+
+
+
+add_custom_target(build_dla DEPENDS ${DLA_BUILD_DIR_RELEASE}/libdla_driver_ffi.a)
+add_custom_target(build_dla-debug DEPENDS ${DLA_BUILD_DIR_DEBUG}/libdla_driver_ffi.a)
+set(DLA_LIBRARIES ${DLA_BUILD_DIR_RELEASE}/libdla_driver_ffi.a)

--- a/examples/hpc/dla-driver-ffi/Cargo.toml
+++ b/examples/hpc/dla-driver-ffi/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dla-driver-ffi"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+dla-driver = { version = "0.1.0", path = "../dla-driver" }
+
+[build-dependencies]
+cbindgen = "0.26.0"
+
+[workspace]
+members = []

--- a/examples/hpc/dla-driver-ffi/Cargo.toml
+++ b/examples/hpc/dla-driver-ffi/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 crate-type = ["staticlib"]
 
 [dependencies]
-dla-driver = { version = "0.1.0", path = "../dla-driver" }
+dla-driver = { version = "0.1.0", path = "../dla-driver", features = ["hpc", "vp"] }
+headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = ["alloc", "sdram"]}
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/examples/hpc/dla-driver-ffi/Cargo.toml
+++ b/examples/hpc/dla-driver-ffi/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 dla-driver = { version = "0.1.0", path = "../dla-driver", features = ["hpc", "vp"] }
-headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = ["alloc", "sdram"]}
+headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = ["alloc", "sdram", "panic-uart"]}
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/examples/hpc/dla-driver-ffi/Justfile
+++ b/examples/hpc/dla-driver-ffi/Justfile
@@ -1,0 +1,2 @@
+build-dla:
+    cargo build --target=riscv64imac-unknown-none-elf --release

--- a/examples/hpc/dla-driver-ffi/Justfile
+++ b/examples/hpc/dla-driver-ffi/Justfile
@@ -1,2 +1,5 @@
 build-dla:
-    cargo build --target=riscv64imac-unknown-none-elf --release
+    cargo objcopy --target=riscv64imac-unknown-none-elf --release --lib -- --weaken
+
+build-dla-debug:
+    cargo objcopy --target=riscv64imac-unknown-none-elf --lib -- --weaken

--- a/examples/hpc/dla-driver-ffi/build.rs
+++ b/examples/hpc/dla-driver-ffi/build.rs
@@ -1,0 +1,26 @@
+use cbindgen::Config;
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let output_file = target_dir().join("dla_driver.h").display().to_string();
+
+    let config = Config::from_file("cbindgen.toml").unwrap();
+
+    cbindgen::generate_with_config(&crate_dir, config)
+        .unwrap()
+        .write_to_file(&output_file);
+}
+
+/// Find the location of the `target/` directory. Note that this may be
+/// overridden by `cmake`, so we also need to check the `CARGO_TARGET_DIR`
+/// variable.
+fn target_dir() -> PathBuf {
+    if let Ok(target) = env::var("CARGO_TARGET_DIR") {
+        PathBuf::from(target)
+    } else {
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("target")
+    }
+}

--- a/examples/hpc/dla-driver-ffi/cbindgen.toml
+++ b/examples/hpc/dla-driver-ffi/cbindgen.toml
@@ -1,0 +1,1 @@
+language="C"

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -338,7 +338,3 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
         core::ptr::copy_nonoverlapping(result.to_buffer().as_mut_ptr(), output, result.get_size())
     };
 }
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -67,7 +67,7 @@ unsafe fn ffi_data_import(
     (input_tensor, kernels_tensor)
 }
 
-/// Initializes DLA by setting up necessary head allocator from headsail-bsp. This should be called only once in the program.
+/// Initializes DLA by setting up necessary heap allocator from headsail-bsp. This should be called only once in the program.
 #[no_mangle]
 pub unsafe extern "C" fn dla_init() {
     headsail_bsp::init_alloc();

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -11,8 +11,9 @@ use core::slice;
 use dla_driver::layers::{conv2d, conv2d_bias, conv2d_bias_relu, conv2d_relu};
 use dla_driver::tensor3::{Order3, Tensor3};
 use dla_driver::tensor4::{Order4, Tensor4};
-use dla_driver::{Padding, SimdBitMode, Stride};
+use dla_driver::{Padding, Stride};
 
+/// Converts C-types to DLA Tensors for use with the highlevel layer
 unsafe fn ffi_data_import(
     input_data: *const i8,
     input_channels: usize,
@@ -66,18 +67,13 @@ unsafe fn ffi_data_import(
     (input_tensor, kernels_tensor)
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn free_rust_vec(ptr: *mut i8, len: usize) {
-    unsafe {
-        let _ = Vec::from_raw_parts(ptr, len, len);
-    }
-}
-
+/// Initializes DLA by setting up necessary head allocator from headsail-bsp. This should be called only once in the program.
 #[no_mangle]
 pub unsafe extern "C" fn dla_init() {
     headsail_bsp::init_alloc();
 }
 
+/// Executes Conv2D on DLA with given parameters and writes result to output buffer.
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d(
     input_data: *const i8,
@@ -141,6 +137,7 @@ pub unsafe extern "C" fn dla_conv2d(
     };
 }
 
+/// Executes Conv2D + ReLU on DLA with given parameters and writes result to output buffer.
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_relu(
     input_data: *const i8,
@@ -204,6 +201,7 @@ pub unsafe extern "C" fn dla_conv2d_relu(
     };
 }
 
+/// Executes Conv2D + Bias on DLA with given parameters and writes result to output buffer.
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias(
     input_data: *const i8,
@@ -272,6 +270,7 @@ pub unsafe extern "C" fn dla_conv2d_bias(
     };
 }
 
+/// Executes Conv2D + Bias + ReLU on DLA with given parameters and writes result to output buffer.
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias_relu(
     input_data: *const i8,

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -1,0 +1,189 @@
+//! # DLA driver
+//!
+//! Implements driver for sochub headsail SoC's deep learning accelerator.
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+use alloc::vec::Vec;
+use core::ffi::c_char;
+use core::slice;
+use dla_driver::layers::conv2d;
+use dla_driver::tensor3::{Order3, Tensor3};
+use dla_driver::tensor4::{Order4, Tensor4};
+use dla_driver::{Padding, SimdBitMode, Stride};
+
+#[repr(C)]
+pub struct COrder3 {
+    order: [c_char; 3],
+}
+
+#[repr(C)]
+pub struct COrder4 {
+    order: [c_char; 4],
+}
+
+// FFI-compatible Tensor3 structure:
+#[repr(C)]
+pub struct CTensor3 {
+    data: *const i8, // Pointer to the data
+    channels: usize,
+    height: usize,
+    width: usize,
+    order: COrder3,
+}
+
+// FFI-compatible Tensor4 structure:
+#[repr(C)]
+pub struct CTensor4 {
+    data: *const i8, // Pointer to the data
+    kernels: usize,
+    channels: usize,
+    height: usize,
+    width: usize,
+    order: COrder4,
+}
+
+#[repr(C)]
+pub struct CPadding {
+    top: u32,
+    bottom: u32,
+    left: u32,
+    right: u32,
+    padding_value: i32,
+}
+
+impl From<CPadding> for Padding {
+    fn from(c_padding: CPadding) -> Self {
+        Padding {
+            top: c_padding.top,
+            right: c_padding.right,
+            left: c_padding.left,
+            bottom: c_padding.bottom,
+            padding_value: c_padding.padding_value,
+        }
+    }
+}
+
+impl From<Padding> for CPadding {
+    fn from(padding: Padding) -> Self {
+        CPadding {
+            top: padding.top,
+            right: padding.right,
+            left: padding.left,
+            bottom: padding.bottom,
+            padding_value: padding.padding_value,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct CStride {
+    x: u32,
+    y: u32,
+}
+
+impl From<CStride> for Stride {
+    fn from(c_stride: CStride) -> Self {
+        Stride {
+            x: c_stride.x,
+            y: c_stride.y,
+        }
+    }
+}
+
+impl From<Stride> for CStride {
+    fn from(stride: Stride) -> Self {
+        CStride {
+            x: stride.x,
+            y: stride.y,
+        }
+    }
+}
+
+#[repr(C)]
+pub enum CSimdBitMode {
+    EightBits = 0,
+    FourBits = 1,
+    TwoBits = 2,
+}
+
+impl From<CSimdBitMode> for SimdBitMode {
+    fn from(c_mode: CSimdBitMode) -> Self {
+        match c_mode {
+            CSimdBitMode::EightBits => SimdBitMode::EightBits,
+            CSimdBitMode::FourBits => SimdBitMode::FourBits,
+            CSimdBitMode::TwoBits => SimdBitMode::TwoBits,
+        }
+    }
+}
+
+impl From<SimdBitMode> for CSimdBitMode {
+    fn from(mode: SimdBitMode) -> Self {
+        match mode {
+            SimdBitMode::EightBits => CSimdBitMode::EightBits,
+            SimdBitMode::FourBits => CSimdBitMode::FourBits,
+            SimdBitMode::TwoBits => CSimdBitMode::TwoBits,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn conv2d_ffi(
+    input: CTensor3,
+    kernels: CTensor4,
+    padding: CPadding,       // Assuming padding is a pointer (nullable)
+    stride: CStride,         // Assuming stride is a pointer (nullable)
+    mac_clip: u32,           // Nullable pointer for optional values
+    pp_clip: u32,            // Nullable pointer for optional values
+    simd_mode: CSimdBitMode, // Nullable pointer for optional values
+    output: *mut CTensor3,   // Output pointer
+) {
+    let input_data: Vec<i8> = unsafe {
+        slice::from_raw_parts(input.data, input.channels * input.height * input.width).to_vec()
+    };
+    let input_tensor = unsafe {
+        Tensor3::from_data_buffer(
+            input.channels,
+            input.height,
+            input.width,
+            input_data,
+            Order3::try_from(input.order.order).unwrap_unchecked(),
+        )
+        .unwrap_unchecked()
+    };
+
+    let kernels_data: Vec<i8> = unsafe {
+        slice::from_raw_parts(
+            kernels.data,
+            kernels.kernels * kernels.channels * kernels.height * kernels.width,
+        )
+        .to_vec()
+    };
+
+    let kernels_tensor = unsafe {
+        Tensor4::from_data_buffer(
+            kernels.kernels,
+            kernels.channels,
+            kernels.height,
+            kernels.width,
+            kernels_data,
+            Order4::try_from(kernels.order.order).unwrap_unchecked(),
+        )
+        .unwrap_unchecked()
+    };
+
+    let result = conv2d(
+        input_tensor,
+        kernels_tensor,
+        Some(Padding::from(padding)),
+        Some(Stride::from(stride)),
+        Some(mac_clip),
+        Some(pp_clip),
+        Some(SimdBitMode::from(simd_mode)),
+    );
+}
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -1,6 +1,6 @@
-//! # DLA driver
+//! # DLA driver FFI
 //!
-//! Implements driver for sochub headsail SoC's deep learning accelerator.
+//! Makes DLA's highlevel API availeable from C via FFI.
 #![no_std]
 #![no_main]
 

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -6,182 +6,337 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use core::ffi::c_char;
+use core::ffi::{c_char, CStr};
 use core::slice;
-use dla_driver::layers::conv2d;
+use dla_driver::layers::{conv2d, conv2d_bias, conv2d_bias_relu, conv2d_relu};
 use dla_driver::tensor3::{Order3, Tensor3};
 use dla_driver::tensor4::{Order4, Tensor4};
 use dla_driver::{Padding, SimdBitMode, Stride};
 
-#[repr(C)]
-pub struct COrder3 {
-    order: [c_char; 3],
-}
-
-#[repr(C)]
-pub struct COrder4 {
-    order: [c_char; 4],
-}
-
-// FFI-compatible Tensor3 structure:
-#[repr(C)]
-pub struct CTensor3 {
-    data: *const i8, // Pointer to the data
-    channels: usize,
-    height: usize,
-    width: usize,
-    order: COrder3,
-}
-
-// FFI-compatible Tensor4 structure:
-#[repr(C)]
-pub struct CTensor4 {
-    data: *const i8, // Pointer to the data
-    kernels: usize,
-    channels: usize,
-    height: usize,
-    width: usize,
-    order: COrder4,
-}
-
-#[repr(C)]
-pub struct CPadding {
-    top: u32,
-    bottom: u32,
-    left: u32,
-    right: u32,
-    padding_value: i32,
-}
-
-impl From<CPadding> for Padding {
-    fn from(c_padding: CPadding) -> Self {
-        Padding {
-            top: c_padding.top,
-            right: c_padding.right,
-            left: c_padding.left,
-            bottom: c_padding.bottom,
-            padding_value: c_padding.padding_value,
-        }
-    }
-}
-
-impl From<Padding> for CPadding {
-    fn from(padding: Padding) -> Self {
-        CPadding {
-            top: padding.top,
-            right: padding.right,
-            left: padding.left,
-            bottom: padding.bottom,
-            padding_value: padding.padding_value,
-        }
-    }
-}
-
-#[repr(C)]
-pub struct CStride {
-    x: u32,
-    y: u32,
-}
-
-impl From<CStride> for Stride {
-    fn from(c_stride: CStride) -> Self {
-        Stride {
-            x: c_stride.x,
-            y: c_stride.y,
-        }
-    }
-}
-
-impl From<Stride> for CStride {
-    fn from(stride: Stride) -> Self {
-        CStride {
-            x: stride.x,
-            y: stride.y,
-        }
-    }
-}
-
-#[repr(C)]
-pub enum CSimdBitMode {
-    EightBits = 0,
-    FourBits = 1,
-    TwoBits = 2,
-}
-
-impl From<CSimdBitMode> for SimdBitMode {
-    fn from(c_mode: CSimdBitMode) -> Self {
-        match c_mode {
-            CSimdBitMode::EightBits => SimdBitMode::EightBits,
-            CSimdBitMode::FourBits => SimdBitMode::FourBits,
-            CSimdBitMode::TwoBits => SimdBitMode::TwoBits,
-        }
-    }
-}
-
-impl From<SimdBitMode> for CSimdBitMode {
-    fn from(mode: SimdBitMode) -> Self {
-        match mode {
-            SimdBitMode::EightBits => CSimdBitMode::EightBits,
-            SimdBitMode::FourBits => CSimdBitMode::FourBits,
-            SimdBitMode::TwoBits => CSimdBitMode::TwoBits,
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn conv2d_ffi(
-    input: CTensor3,
-    kernels: CTensor4,
-    padding: CPadding,       // Assuming padding is a pointer (nullable)
-    stride: CStride,         // Assuming stride is a pointer (nullable)
-    mac_clip: u32,           // Nullable pointer for optional values
-    pp_clip: u32,            // Nullable pointer for optional values
-    simd_mode: CSimdBitMode, // Nullable pointer for optional values
-    output: *mut CTensor3,   // Output pointer
-) {
+unsafe fn ffi_data_import(
+    input_data: *const i8,
+    input_channels: usize,
+    input_height: usize,
+    input_width: usize,
+    input_order: *const c_char,
+    kernel_data: *const i8,
+    kernel_amount: usize,
+    kernel_channels: usize,
+    kernel_height: usize,
+    kernel_width: usize,
+    kernel_order: *const c_char,
+) -> (Tensor3<i8>, Tensor4<i8>) {
     let input_data: Vec<i8> = unsafe {
-        slice::from_raw_parts(input.data, input.channels * input.height * input.width).to_vec()
+        slice::from_raw_parts(input_data, input_channels * input_height * input_width).to_vec()
     };
+
+    let input_order_string = unsafe { CStr::from_ptr(input_order).to_str().unwrap_unchecked() };
     let input_tensor = unsafe {
         Tensor3::from_data_buffer(
-            input.channels,
-            input.height,
-            input.width,
+            input_channels,
+            input_height,
+            input_width,
             input_data,
-            Order3::try_from(input.order.order).unwrap_unchecked(),
+            Order3::try_from(input_order_string).unwrap_unchecked(),
         )
         .unwrap_unchecked()
     };
 
     let kernels_data: Vec<i8> = unsafe {
         slice::from_raw_parts(
-            kernels.data,
-            kernels.kernels * kernels.channels * kernels.height * kernels.width,
+            kernel_data,
+            kernel_amount * kernel_channels * kernel_height * kernel_width,
         )
         .to_vec()
     };
 
+    let kernel_order_string = unsafe { CStr::from_ptr(kernel_order).to_str().unwrap_unchecked() };
     let kernels_tensor = unsafe {
         Tensor4::from_data_buffer(
-            kernels.kernels,
-            kernels.channels,
-            kernels.height,
-            kernels.width,
+            kernel_amount,
+            kernel_channels,
+            kernel_height,
+            kernel_width,
             kernels_data,
-            Order4::try_from(kernels.order.order).unwrap_unchecked(),
+            Order4::try_from(kernel_order_string).unwrap_unchecked(),
         )
         .unwrap_unchecked()
     };
 
-    let result = conv2d(
+    (input_tensor, kernels_tensor)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn free_rust_vec(ptr: *mut i8, len: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, len, len);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dla_init() {
+    headsail_bsp::init_alloc();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dla_conv2d(
+    input_data: *const i8,
+    input_channels: usize,
+    input_height: usize,
+    input_width: usize,
+    input_order: *const c_char,
+    kernel_data: *const i8,
+    kernel_amount: usize,
+    kernel_channels: usize,
+    kernel_height: usize,
+    kernel_width: usize,
+    kernel_order: *const c_char,
+    pad_top: u32,
+    pad_right: u32,
+    pad_left: u32,
+    pad_bottom: u32,
+    pad_value: i32,
+    stride_x: u32,
+    stride_y: u32,
+    mac_clip: u32,
+    pp_clip: u32,
+    output: *mut i8,
+) {
+    let (input_tensor, kernels_tensor) = unsafe {
+        ffi_data_import(
+            input_data,
+            input_channels,
+            input_height,
+            input_width,
+            input_order,
+            kernel_data,
+            kernel_amount,
+            kernel_channels,
+            kernel_height,
+            kernel_width,
+            kernel_order,
+        )
+    };
+
+    let result: Tensor3<i8> = conv2d(
         input_tensor,
         kernels_tensor,
-        Some(Padding::from(padding)),
-        Some(Stride::from(stride)),
+        Some(Padding {
+            top: pad_top,
+            right: pad_right,
+            left: pad_left,
+            bottom: pad_bottom,
+            padding_value: pad_value,
+        }),
+        Some(Stride {
+            x: stride_x,
+            y: stride_y,
+        }),
         Some(mac_clip),
         Some(pp_clip),
-        Some(SimdBitMode::from(simd_mode)),
+        None,
     );
+    unsafe {
+        core::ptr::copy_nonoverlapping(result.to_buffer().as_mut_ptr(), output, result.get_size())
+    };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dla_conv2d_relu(
+    input_data: *const i8,
+    input_channels: usize,
+    input_height: usize,
+    input_width: usize,
+    input_order: *const c_char,
+    kernel_data: *const i8,
+    kernel_amount: usize,
+    kernel_channels: usize,
+    kernel_height: usize,
+    kernel_width: usize,
+    kernel_order: *const c_char,
+    pad_top: u32,
+    pad_right: u32,
+    pad_left: u32,
+    pad_bottom: u32,
+    pad_value: i32,
+    stride_x: u32,
+    stride_y: u32,
+    mac_clip: u32,
+    pp_clip: u32,
+    output: *mut i8,
+) {
+    let (input_tensor, kernels_tensor) = unsafe {
+        ffi_data_import(
+            input_data,
+            input_channels,
+            input_height,
+            input_width,
+            input_order,
+            kernel_data,
+            kernel_amount,
+            kernel_channels,
+            kernel_height,
+            kernel_width,
+            kernel_order,
+        )
+    };
+
+    let result: Tensor3<i8> = conv2d_relu(
+        input_tensor,
+        kernels_tensor,
+        Some(Padding {
+            top: pad_top,
+            right: pad_right,
+            left: pad_left,
+            bottom: pad_bottom,
+            padding_value: pad_value,
+        }),
+        Some(Stride {
+            x: stride_x,
+            y: stride_y,
+        }),
+        Some(mac_clip),
+        Some(pp_clip),
+        None,
+    );
+    unsafe {
+        core::ptr::copy_nonoverlapping(result.to_buffer().as_mut_ptr(), output, result.get_size())
+    };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dla_conv2d_bias(
+    input_data: *const i8,
+    input_channels: usize,
+    input_height: usize,
+    input_width: usize,
+    input_order: *const c_char,
+    kernel_data: *const i8,
+    kernel_amount: usize,
+    kernel_channels: usize,
+    kernel_height: usize,
+    kernel_width: usize,
+    kernel_order: *const c_char,
+    bias: *const i16,
+    bias_length: usize,
+    pad_top: u32,
+    pad_right: u32,
+    pad_left: u32,
+    pad_bottom: u32,
+    pad_value: i32,
+    stride_x: u32,
+    stride_y: u32,
+    mac_clip: u32,
+    pp_clip: u32,
+    output: *mut i8,
+) {
+    let (input_tensor, kernels_tensor) = unsafe {
+        ffi_data_import(
+            input_data,
+            input_channels,
+            input_height,
+            input_width,
+            input_order,
+            kernel_data,
+            kernel_amount,
+            kernel_channels,
+            kernel_height,
+            kernel_width,
+            kernel_order,
+        )
+    };
+
+    let bias: Vec<i16> = unsafe { slice::from_raw_parts(bias, bias_length).to_vec() };
+
+    let result = conv2d_bias(
+        input_tensor,
+        kernels_tensor,
+        bias,
+        Some(Padding {
+            top: pad_top,
+            right: pad_right,
+            left: pad_left,
+            bottom: pad_bottom,
+            padding_value: pad_value,
+        }),
+        Some(Stride {
+            x: stride_x,
+            y: stride_y,
+        }),
+        Some(mac_clip),
+        Some(pp_clip),
+        None,
+    );
+    unsafe {
+        core::ptr::copy_nonoverlapping(result.to_buffer().as_mut_ptr(), output, result.get_size())
+    };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dla_conv2d_bias_relu(
+    input_data: *const i8,
+    input_channels: usize,
+    input_height: usize,
+    input_width: usize,
+    input_order: *const c_char,
+    kernel_data: *const i8,
+    kernel_amount: usize,
+    kernel_channels: usize,
+    kernel_height: usize,
+    kernel_width: usize,
+    kernel_order: *const c_char,
+    bias: *const i16,
+    bias_length: usize,
+    pad_top: u32,
+    pad_right: u32,
+    pad_left: u32,
+    pad_bottom: u32,
+    pad_value: i32,
+    stride_x: u32,
+    stride_y: u32,
+    mac_clip: u32,
+    pp_clip: u32,
+    output: *mut i8,
+) {
+    let (input_tensor, kernels_tensor) = unsafe {
+        ffi_data_import(
+            input_data,
+            input_channels,
+            input_height,
+            input_width,
+            input_order,
+            kernel_data,
+            kernel_amount,
+            kernel_channels,
+            kernel_height,
+            kernel_width,
+            kernel_order,
+        )
+    };
+    let bias: Vec<i16> = unsafe { slice::from_raw_parts(bias, bias_length).to_vec() };
+
+    let result = conv2d_bias_relu(
+        input_tensor,
+        kernels_tensor,
+        bias,
+        Some(Padding {
+            top: pad_top,
+            right: pad_right,
+            left: pad_left,
+            bottom: pad_bottom,
+            padding_value: pad_value,
+        }),
+        Some(Stride {
+            x: stride_x,
+            y: stride_y,
+        }),
+        Some(mac_clip),
+        Some(pp_clip),
+        None,
+    );
+    unsafe {
+        core::ptr::copy_nonoverlapping(result.to_buffer().as_mut_ptr(), output, result.get_size())
+    };
 }
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/examples/hpc/dla-driver/src/layers.rs
+++ b/examples/hpc/dla-driver/src/layers.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use crate::utils::{calculate_conv2d_out_param_dim, get_banks_for_layer};
 
 // Define a trait for output handling
-trait DlaOutput: Sized {
+pub trait DlaOutput: Sized {
     fn read_output(dla: &Dla, size: usize) -> Vec<Self>;
 }
 

--- a/examples/hpc/dla-driver/src/layers.rs
+++ b/examples/hpc/dla-driver/src/layers.rs
@@ -51,7 +51,7 @@ pub fn dense(outputs: usize, input: Tensor3<i8>, weights: Vec<i8>) -> Vec<i32> {
     output.to_buffer()
 }
 
-pub fn conv2d(
+pub fn conv2d<T: DlaOutput + Clone>(
     input: Tensor3<i8>,
     kernels: Tensor4<i8>,
     padding: Option<Padding>,
@@ -59,7 +59,7 @@ pub fn conv2d(
     mac_clip: Option<u32>,
     pp_clip: Option<u32>,
     simd_mode: Option<SimdBitMode>,
-) -> Tensor3<i32> {
+) -> Tensor3<T> {
     run_layers(
         input, kernels, None, false, false, padding, stride, mac_clip, pp_clip, simd_mode,
     )
@@ -117,7 +117,7 @@ pub fn bias(input: Tensor3<i8>, bias: Vec<i16>, pp_clip: Option<u32>) -> Tensor3
     )
 }
 
-pub fn conv2d_relu(
+pub fn conv2d_relu<T: DlaOutput + Clone>(
     input: Tensor3<i8>,
     kernels: Tensor4<i8>,
     padding: Option<Padding>,
@@ -125,13 +125,13 @@ pub fn conv2d_relu(
     mac_clip: Option<u32>,
     pp_clip: Option<u32>,
     simd_mode: Option<SimdBitMode>,
-) -> Tensor3<i8> {
+) -> Tensor3<T> {
     run_layers(
         input, kernels, None, false, true, padding, stride, mac_clip, pp_clip, simd_mode,
     )
 }
 
-pub fn conv2d_bias(
+pub fn conv2d_bias<T: DlaOutput + Clone>(
     input: Tensor3<i8>,
     kernels: Tensor4<i8>,
     bias: Vec<i16>,
@@ -140,7 +140,7 @@ pub fn conv2d_bias(
     mac_clip: Option<u32>,
     pp_clip: Option<u32>,
     simd_mode: Option<SimdBitMode>,
-) -> Tensor3<i8> {
+) -> Tensor3<T> {
     run_layers(
         input,
         kernels,
@@ -155,7 +155,7 @@ pub fn conv2d_bias(
     )
 }
 
-pub fn conv2d_bias_relu(
+pub fn conv2d_bias_relu<T: DlaOutput + Clone>(
     input: Tensor3<i8>,
     kernels: Tensor4<i8>,
     bias: Vec<i16>,
@@ -164,7 +164,7 @@ pub fn conv2d_bias_relu(
     mac_clip: Option<u32>,
     pp_clip: Option<u32>,
     simd_mode: Option<SimdBitMode>,
-) -> Tensor3<i8> {
+) -> Tensor3<T> {
     run_layers(
         input,
         kernels,

--- a/examples/hpc/dla-driver/src/lib.rs
+++ b/examples/hpc/dla-driver/src/lib.rs
@@ -95,7 +95,7 @@ pub struct Padding {
     pub right: u32,
     pub left: u32,
     pub bottom: u32,
-    pub padding_value: u32,
+    pub padding_value: i32,
 }
 
 /// Conv2d stride

--- a/examples/hpc/dla-driver/src/tensor3.rs
+++ b/examples/hpc/dla-driver/src/tensor3.rs
@@ -1,4 +1,6 @@
+use alloc::boxed::Box;
 use alloc::vec::*;
+use core::ffi::c_char;
 use ndarray::{Array, Array3};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -34,6 +36,22 @@ impl TryFrom<&str> for Order3 {
             "HCW" => Ok(Order3::HCW),
             "WHC" => Ok(Order3::WHC),
             "WCH" => Ok(Order3::WCH),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<[c_char; 3]> for Order3 {
+    type Error = ();
+    fn try_from(s: [c_char; 3]) -> Result<Self, Self::Error> {
+        match s {
+            // C = 0x43, H = 0x48, W = 0x57
+            [0x43, 0x48, 0x57] => Ok(Order3::CHW),
+            [0x43, 0x57, 0x48] => Ok(Order3::CWH),
+            [0x48, 0x57, 0x43] => Ok(Order3::HWC),
+            [0x48, 0x43, 0x57] => Ok(Order3::HCW),
+            [0x57, 0x48, 0x43] => Ok(Order3::WHC),
+            [0x57, 0x43, 0x48] => Ok(Order3::WCH),
             _ => Err(()),
         }
     }

--- a/examples/hpc/dla-driver/src/tensor3.rs
+++ b/examples/hpc/dla-driver/src/tensor3.rs
@@ -24,6 +24,21 @@ impl Order3 {
     }
 }
 
+impl TryFrom<&str> for Order3 {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "CHW" => Ok(Order3::CHW),
+            "CWH" => Ok(Order3::CWH),
+            "HWC" => Ok(Order3::HWC),
+            "HCW" => Ok(Order3::HCW),
+            "WHC" => Ok(Order3::WHC),
+            "WCH" => Ok(Order3::WCH),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Tensor3<T> {
     data: Array3<T>,

--- a/examples/hpc/dla-driver/src/tensor3.rs
+++ b/examples/hpc/dla-driver/src/tensor3.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use alloc::vec::*;
 use core::ffi::c_char;
 use ndarray::{Array, Array3};

--- a/examples/hpc/dla-driver/src/tensor4.rs
+++ b/examples/hpc/dla-driver/src/tensor4.rs
@@ -60,6 +60,39 @@ impl Order4 {
     }
 }
 
+impl TryFrom<&str> for Order4 {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "KCHW" => Ok(Order4::KCHW),
+            "KCWH" => Ok(Order4::KCWH),
+            "KHWC" => Ok(Order4::KHWC),
+            "KHCW" => Ok(Order4::KHCW),
+            "KWHC" => Ok(Order4::KWHC),
+            "KWCH" => Ok(Order4::KWCH),
+            "CKHW" => Ok(Order4::CKHW),
+            "CKWH" => Ok(Order4::CKWH),
+            "CHWK" => Ok(Order4::CHWK),
+            "CHKW" => Ok(Order4::CHKW),
+            "CWKH" => Ok(Order4::CWKH),
+            "CWHK" => Ok(Order4::CWHK),
+            "HKCW" => Ok(Order4::HKCW),
+            "HKWC" => Ok(Order4::HKWC),
+            "HCKW" => Ok(Order4::HCKW),
+            "HCWK" => Ok(Order4::HCWK),
+            "HWCK" => Ok(Order4::HWCK),
+            "HWKC" => Ok(Order4::HWKC),
+            "WKCH" => Ok(Order4::WKCH),
+            "WKHC" => Ok(Order4::WKHC),
+            "WCKH" => Ok(Order4::WCKH),
+            "WCHK" => Ok(Order4::WCHK),
+            "WHCK" => Ok(Order4::WHCK),
+            "WHKC" => Ok(Order4::WHKC),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Tensor4<T> {
     data: Array4<T>,

--- a/examples/hpc/dla-driver/src/tensor4.rs
+++ b/examples/hpc/dla-driver/src/tensor4.rs
@@ -1,4 +1,5 @@
 use alloc::vec::*;
+use core::ffi::c_char;
 use ndarray::{Array, Array4};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -88,6 +89,40 @@ impl TryFrom<&str> for Order4 {
             "WCHK" => Ok(Order4::WCHK),
             "WHCK" => Ok(Order4::WHCK),
             "WHKC" => Ok(Order4::WHKC),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<[c_char; 4]> for Order4 {
+    type Error = ();
+    fn try_from(s: [c_char; 4]) -> Result<Self, Self::Error> {
+        match s {
+            // K = 0x4B, C = 0x43, H = 0x48, W = 0x57
+            [0x4B, 0x43, 0x48, 0x57] => Ok(Order4::KCHW),
+            [0x4B, 0x43, 0x57, 0x48] => Ok(Order4::KCWH),
+            [0x4B, 0x48, 0x57, 0x43] => Ok(Order4::KHWC),
+            [0x4B, 0x48, 0x43, 0x57] => Ok(Order4::KHCW),
+            [0x4B, 0x57, 0x48, 0x43] => Ok(Order4::KWHC),
+            [0x4B, 0x57, 0x43, 0x48] => Ok(Order4::KWCH),
+            [0x43, 0x4B, 0x48, 0x57] => Ok(Order4::CKHW),
+            [0x43, 0x4B, 0x57, 0x48] => Ok(Order4::CKWH),
+            [0x43, 0x48, 0x57, 0x4B] => Ok(Order4::CHWK),
+            [0x43, 0x48, 0x4B, 0x57] => Ok(Order4::CHKW),
+            [0x43, 0x57, 0x4B, 0x48] => Ok(Order4::CWKH),
+            [0x43, 0x57, 0x48, 0x4B] => Ok(Order4::CWHK),
+            [0x48, 0x4B, 0x43, 0x57] => Ok(Order4::HKCW),
+            [0x48, 0x4B, 0x57, 0x43] => Ok(Order4::HKWC),
+            [0x48, 0x43, 0x4B, 0x57] => Ok(Order4::HCKW),
+            [0x48, 0x43, 0x57, 0x4B] => Ok(Order4::HCWK),
+            [0x48, 0x57, 0x43, 0x4B] => Ok(Order4::HWCK),
+            [0x48, 0x57, 0x4B, 0x43] => Ok(Order4::HWKC),
+            [0x57, 0x4B, 0x43, 0x48] => Ok(Order4::WKCH),
+            [0x57, 0x4B, 0x48, 0x43] => Ok(Order4::WKHC),
+            [0x57, 0x43, 0x4B, 0x48] => Ok(Order4::WCKH),
+            [0x57, 0x43, 0x48, 0x4B] => Ok(Order4::WCHK),
+            [0x57, 0x48, 0x43, 0x4B] => Ok(Order4::WHCK),
+            [0x57, 0x48, 0x4B, 0x43] => Ok(Order4::WHKC),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
Adds FFI for DLA layer API to be used from C. This is necessary to run TVM acceleration since the TVM graph executor calls these bindings.