### PR TITLE
Sanitize print/panic impls to allow switching between TLP & SysCtrl

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install requirements
-      run: rustup target add riscv64imac-unknown-none-elf riscv32im-unknown-none-elf
+      run: |
+        rustup update
+        rustup target add riscv64imac-unknown-none-elf riscv32im-unknown-none-elf
 
     - name: Run linter
       working-directory: ./examples/headsail-bsp
@@ -63,7 +65,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install requirements
-      run: rustup target add riscv64imac-unknown-none-elf
+      run: |
+        rustup update
+        rustup target add riscv64imac-unknown-none-elf
     - name: Run linter
       working-directory: ./examples/hpc/
       run: cargo clippy -- -D clippy::style
@@ -170,7 +174,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install requirements
-      run: rustup target add riscv64imac-unknown-none-elf riscv32im-unknown-none-elf
+      run: |
+        rustup update
+        rustup target add riscv64imac-unknown-none-elf riscv32im-unknown-none-elf
     - name: Build FFI without RT on SysCtrl
       working-directory: ./examples/headsail-bsp-ffi
       run: cargo build --target=riscv32im-unknown-none-elf -Fpanic-apb-uart0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
     "rust-analyzer.linkedProjects": [
         "examples/headsail-bsp/Cargo.toml",
-        "examples/headsail-bsp-ffi/Cargo.toml",
-        "examples/hpc/Cargo.toml",
-        "examples/sysctrl/Cargo.toml",
     ],
     // rust-analyzer.check.allTargets & rust-analyzer.cargo.extraArgs are required to prevent "can't
     // find std for crate test"

--- a/examples/headsail-bsp/Cargo.toml
+++ b/examples/headsail-bsp/Cargo.toml
@@ -13,12 +13,18 @@ sysctrl-rt = [
     "riscv-rt/single-hart",
     "riscv/critical-section-single-hart",
 ]
-panic-apb-uart0 = []
+panic-apb-uart0 = ["sprint-apb-uart0"]
+panic-sysctrl-uart = ["sysctrl-pac"]
+sprint-apb-uart0 = []
 hpc = ["dep:riscv-pac", "dep:riscv-peripheral"]
 sysctrl = []
 alloc = ["dep:good_memory_allocator", "hpc"]
 sdram = []
-vp = []
+vp = [
+    # VP only supports printing over APB UART0 since uDMA is not implemented on it so we force it
+    # here to avoid accidents.
+    "sprint-apb-uart0",
+]
 asic = []
 sysctrl-pac = ["dep:headsail-sysctrl-pac", "sysctrl", "pac"]
 hpc-pac = ["dep:headsail-hpc-pac", "hpc", "pac"]
@@ -57,7 +63,7 @@ required-features = ["alloc", "rt", "sdram"]
 [[example]]
 name = "sprintln"
 path = "examples/sprintln.rs"
-required-features = ["rt"]
+required-features = ["rt", "sprint-apb-uart0"]
 
 [[example]]
 name = "alloc"

--- a/examples/headsail-bsp/Cargo.toml
+++ b/examples/headsail-bsp/Cargo.toml
@@ -29,6 +29,7 @@ pac = []
 
 [dependencies]
 ufmt = "0.2.0"
+ufmt-write = "0.1.0"
 riscv-rt = { version = "0.12.2", optional = true }
 riscv = { version = "0.11.1" }
 riscv-peripheral = { version = "0.1.0", optional = true }

--- a/examples/headsail-bsp/Cargo.toml
+++ b/examples/headsail-bsp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-hpc-rt = ["hpc", "rt", "dep:riscv-peripheral", "dep:riscv-pac"]
+hpc-rt = ["hpc", "rt"]
 sysctrl-rt = [
     "sysctrl",
     "rt",
@@ -14,7 +14,7 @@ sysctrl-rt = [
     "riscv/critical-section-single-hart",
 ]
 panic-apb-uart0 = []
-hpc = []
+hpc = ["dep:riscv-pac", "dep:riscv-peripheral"]
 sysctrl = []
 alloc = ["dep:good_memory_allocator", "hpc"]
 sdram = []

--- a/examples/headsail-bsp/Justfile
+++ b/examples/headsail-bsp/Justfile
@@ -1,17 +1,22 @@
 run example target='riscv64imac':
-	cargo run --example {{example}} -Fhpc-rt -Fpanic-apb-uart0 --target {{target}}-unknown-none-elf
+	cargo run -Fvp --example {{example}} -Fhpc-rt -Fpanic-apb-uart0 --target {{target}}-unknown-none-elf
 
-check-hpc:
-    cargo check --examples -Fhpc-rt -Fpanic-apb-uart0 -Falloc --target riscv64imac-unknown-none-elf
+check-hpc *args:
+    cargo check -Fhpc -Falloc --target riscv64imac-unknown-none-elf {{args}}
+    cargo check --examples -Fhpc-rt -Fpanic-apb-uart0 -Falloc --target riscv64imac-unknown-none-elf {{args}}
 
-check-sysctrl:
-    cargo check --examples -Fsysctrl-rt -Fpanic-apb-uart0 --target riscv32im-unknown-none-elf
+check-sysctrl *args:
+    cargo check -Fsysctrl --target riscv32im-unknown-none-elf {{args}}
+    cargo check --examples -Fsysctrl-rt -Fpanic-sysctrl-uart --target riscv32im-unknown-none-elf {{args}}
 
-clippy-hpc:
-    cargo clippy --examples -Fhpc-rt -Fpanic-apb-uart0 -Falloc --target riscv64imac-unknown-none-elf -- -Dclippy::style
+check *args: (check-hpc args) (check-sysctrl args)
 
-clippy-sysctrl:
-    cargo clippy --examples -Fsysctrl-rt -Fpanic-apb-uart0 --target riscv32im-unknown-none-elf -- -Dclippy::style
+clippy-hpc *args:
+    cargo clippy -Fhpc -Falloc --target riscv64imac-unknown-none-elf {{args}} -- -Dclippy::style
+    cargo clippy --examples -Fhpc-rt -Fpanic-apb-uart0 -Falloc --target riscv64imac-unknown-none-elf {{args}}  -- -Dclippy::style
 
-clippy: clippy-sysctrl clippy-hpc
+clippy-sysctrl *args:
+    cargo clippy -Fsysctrl --target riscv32im-unknown-none-elf {{args}} -- -Dclippy::style
+    cargo clippy --examples -Fsysctrl-rt -Fsysctrl-rt -Fpanic-sysctrl-uart --target riscv32im-unknown-none-elf {{args}} -- -Dclippy::style
 
+clippy *args: (clippy-sysctrl args) (clippy-hpc args)

--- a/examples/headsail-bsp/examples/uart0.rs
+++ b/examples/headsail-bsp/examples/uart0.rs
@@ -8,5 +8,7 @@ fn main() -> ! {
     let (soc_freq, baud) = (30_000_000, 115_200);
     let mut uart = ApbUart0::init(soc_freq, baud);
     uart.write_str("Hello world!");
-    loop {}
+    loop {
+        unsafe { core::arch::asm!("wfi") };
+    }
 }

--- a/examples/headsail-bsp/src/apb_uart.rs
+++ b/examples/headsail-bsp/src/apb_uart.rs
@@ -156,3 +156,12 @@ impl<const BASE_ADDR: usize> ApbUart<BASE_ADDR> {
         result
     }
 }
+
+impl ufmt_write::uWrite for crate::apb_uart::ApbUart0 {
+    type Error = core::convert::Infallible;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        self.write_str(s);
+        Ok(())
+    }
+}

--- a/examples/headsail-bsp/src/lib.rs
+++ b/examples/headsail-bsp/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 pub mod apb_uart;
+#[cfg(feature = "sprint-apb-uart0")]
 pub mod sprintln;
 #[cfg(feature = "sysctrl")]
 pub mod sysctrl;
@@ -44,7 +45,7 @@ pub mod alloc;
 #[cfg(feature = "hpc")]
 mod hpc;
 pub mod mmap;
-#[cfg(feature = "panic-apb-uart0")]
+#[cfg(any(feature = "panic-apb-uart0", feature = "panic-sysctrl-uart"))]
 mod ufmt_panic;
 
 /// # Safety

--- a/examples/headsail-bsp/src/sprintln.rs
+++ b/examples/headsail-bsp/src/sprintln.rs
@@ -27,12 +27,3 @@ macro_rules! sprintln {
         sprint!("\r\n");
     }};
 }
-
-impl ufmt::uWrite for ApbUart0 {
-    type Error = core::convert::Infallible;
-
-    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.write_str(s);
-        Ok(())
-    }
-}

--- a/examples/headsail-bsp/src/sprintln.rs
+++ b/examples/headsail-bsp/src/sprintln.rs
@@ -1,6 +1,5 @@
-//! Macros to implement Rust-style print formatting using `print`/`println`
-use crate::apb_uart::ApbUart0;
-pub const UART: ApbUart0 = unsafe { ApbUart0::instance() };
+//! Macros to implement Rust-style print formatting using `sprint`/`sprintln`
+pub const UART: crate::apb_uart::ApbUart0 = unsafe { crate::apb_uart::ApbUart0::instance() };
 
 #[macro_export]
 macro_rules! sprint {

--- a/examples/headsail-bsp/src/sysctrl/udma.rs
+++ b/examples/headsail-bsp/src/sysctrl/udma.rs
@@ -24,7 +24,7 @@ pub struct UdmaParts<'u> {
 impl<'u> Udma<'u> {
     pub fn split(self) -> UdmaParts<'u> {
         UdmaParts {
-            uart: UdmaUart::<Disabled>(self.0, PhantomData::default()),
+            uart: UdmaUart::<Disabled>(self.0, PhantomData),
         }
     }
 }

--- a/examples/headsail-bsp/src/sysctrl/udma/uart.rs
+++ b/examples/headsail-bsp/src/sysctrl/udma/uart.rs
@@ -70,3 +70,12 @@ impl<'u> UdmaUart<'u, Enabled> {
         self.write(s.as_bytes());
     }
 }
+
+impl<'a> ufmt_write::uWrite for UdmaUart<'a, Enabled> {
+    type Error = core::convert::Infallible;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}

--- a/examples/headsail-bsp/src/sysctrl/udma/uart.rs
+++ b/examples/headsail-bsp/src/sysctrl/udma/uart.rs
@@ -26,7 +26,7 @@ impl<'u> UdmaUart<'u, Disabled> {
         udma.uart_setup().write(|w| unsafe { w.bits(0) });
         udma.uart_setup().write(setup_spec);
 
-        UdmaUart::<Enabled>(self.0, PhantomData::default())
+        UdmaUart::<Enabled>(self.0, PhantomData)
     }
 }
 
@@ -34,7 +34,7 @@ impl<'u> UdmaUart<'u, Enabled> {
     #[inline]
     pub fn disable(self) -> UdmaUart<'u, Disabled> {
         self.0.ctrl_cfg_cg().modify(|_r, w| w.cg_uart().clear_bit());
-        UdmaUart::<Disabled>(self.0, PhantomData::default())
+        UdmaUart::<Disabled>(self.0, PhantomData)
     }
 
     /// # Safety
@@ -42,7 +42,7 @@ impl<'u> UdmaUart<'u, Enabled> {
     /// This will not configure the UART in any way.
     #[inline]
     pub unsafe fn steal(udma: &'static pac::sysctrl::Udma) -> Self {
-        Self(udma, PhantomData::default())
+        Self(udma, PhantomData)
     }
 
     #[inline]

--- a/examples/hpc/dla-driver/Cargo.toml
+++ b/examples/hpc/dla-driver/Cargo.toml
@@ -14,6 +14,7 @@ headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = [
     "hpc-rt",
     "alloc",
     "sdram",
+    "sprint-apb-uart0",
 ] }
 
 

--- a/examples/hpc/hello-dla/Cargo.toml
+++ b/examples/hpc/hello-dla/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 panic-halt = "0.2.0"
 headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = [
     "hpc-rt",
+    "sprint-apb-uart0",
 ] }

--- a/examples/hpc/test-memory-maps/Cargo.toml
+++ b/examples/hpc/test-memory-maps/Cargo.toml
@@ -8,6 +8,7 @@ panic-halt = "0.2.0"
 bsp = { version = "0.1.0", path = "../../headsail-bsp", package = "headsail-bsp", features = [
     "hpc-rt",
     "vp",
+    "sprint-apb-uart0",
 ] }
 
 [build-dependencies]

--- a/examples/sysctrl/hello-sysctrl/Cargo.toml
+++ b/examples/sysctrl/hello-sysctrl/Cargo.toml
@@ -12,5 +12,5 @@ asic = ["headsail-bsp/asic"]
 headsail-bsp = { version = "0.1.0", path = "../../headsail-bsp", features = [
     "sysctrl-rt",
     "sysctrl-pac",
-    "panic-apb-uart0",
+    "panic-sysctrl-uart",
 ] }

--- a/examples/sysctrl/hello-sysctrl/examples/udma_uart_pac.rs
+++ b/examples/sysctrl/hello-sysctrl/examples/udma_uart_pac.rs
@@ -58,6 +58,6 @@ fn main() -> ! {
     while udma.uart_tx_saddr().read().bits() != 0 {}
 
     loop {
-        continue;
+        unsafe { core::arch::asm!("wfi") };
     }
 }

--- a/examples/sysctrl/hello-sysctrl/src/lib.rs
+++ b/examples/sysctrl/hello-sysctrl/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+use headsail_bsp::pac::Sysctrl;
 
 /// Print the name of the current file, i.e., test name.
 ///
@@ -8,8 +9,10 @@
 #[macro_export]
 macro_rules! print_example_name {
     () => {
-        use headsail_bsp::sprintln;
-        sprintln!("[{}]", core::file!());
+        use $crate::sysctrl_print;
+        sysctrl_print(b"[");
+        sysctrl_print(core::file!().as_bytes());
+        sysctrl_print(b"]");
     };
 }
 
@@ -22,3 +25,23 @@ pub const NOPS_PER_SEC: usize = match () {
     // This is just a guess for now (10x debug)
     () => 20_000_000 / 9,
 };
+
+/// Make sure to enable uDMA UART prior to using this function
+pub fn sysctrl_print(buf: &[u8]) {
+    let sysctrl = Sysctrl::ptr();
+    let udma = unsafe { (*sysctrl).udma() };
+
+    udma.uart_tx_saddr()
+        .write(|w| unsafe { w.bits(buf.as_ptr() as u32) });
+    udma.uart_tx_size()
+        .write(|w| unsafe { w.bits(buf.len() as u32) });
+
+    // (3) Dispatch transmission
+    udma.uart_tx_cfg().write(
+        |w| w.en().set_bit(), // If we want "continuous mode". In continuous mode, uDMA reloads the address and transmits it again
+                              //.continous().set_bit()
+    );
+
+    // (4) Poll until finished
+    while udma.uart_tx_saddr().read().bits() != 0 {}
+}


### PR DESCRIPTION
Adding a little bit of flexibility to which UART can be used on which platform.

Also includes an improvement in panic messages enabled by Rust 1.81.