### PR TITLE
Add TVM compatible interface to dla-ffi

### DIFF
--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -275,11 +275,38 @@ pub unsafe extern "C" fn dla_conv2d_relu(
 }
 
 /// Executes Conv2D + Bias on DLA with given parameters and writes result to output buffer.
+/// # Arguments
+///
+/// * `input_data` - Input data  
+/// * `kernel_data` - Kernel/weight data
+/// * `bias` - Buffer containing bias data. NOTE: Bias is actually i16 in hardware, here we use 32 for TVM compatibility
+/// * `output` - Buffer for operation output
+/// * `input_channels` - Number of channels in the input
+/// * `input_height` - Height of the input
+/// * `input_width` - Width of the input
+/// * `input_order` - Layout of the input data
+/// * `input_zero` - Possible zero point correction value
+/// * `kernel_amount` - Number of output channels
+/// * `kernel_channels` - Number of input channels
+/// * `kernel_height` - Kernel height
+/// * `kernel_width` - Kernel width
+/// * `kernel_order` - Kernel data layout
+/// * `bias_length` - Size of the bias fifo
+/// * `pad_top` - Amount of padding on top of the data
+/// * `pad_right` - Amount of padding on right side of the data
+/// * `pad_left` - Amount of padding on left side of the data
+/// * `pad_bottom` - Amount of padding on bottom of the data
+/// * `pad_value` - Integer value used for padding the data
+/// * `stride_x` - Horizontal stride
+/// * `stride_y` - Vertical stride
+/// * `mac_clip` - Amount of bits clipped at the end of the convolution
+/// * `pp_clip` - Amount of bits clipped at the end of the post processing
+
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias(
     input_data: *const i8,
     kernel_data: *const i8,
-    // NOTE: bias is actually i16 in hardware, here we use 32 for TVM compatibility
+    // NOTE:
     bias: *const i32,
     output: *mut i8,
     input_channels: usize,
@@ -351,7 +378,7 @@ pub unsafe extern "C" fn dla_conv2d_bias(
 ///
 /// * `input_data` - Input data  
 /// * `kernel_data` - Kernel/weight data
-/// * `bias` - Buffer containing bias data
+/// * `bias` - Buffer containing bias data. NOTE: Bias is actually i16 in hardware, here we use 32 for TVM compatibility
 /// * `output` - Buffer for operation output
 /// * `input_channels` - Number of channels in the input
 /// * `input_height` - Height of the input
@@ -459,7 +486,7 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
 ///
 /// * `input_data` - Input data  
 /// * `kernel_data` - Kernel/weight data
-/// * `bias` - Buffer containing bias data
+/// * `bias` - Buffer containing bias data. NOTE: Bias is actually i16 in hardware, here we use 32 for TVM compatibility
 /// * `output` - Buffer for operation output
 /// * `output_scale` - Multiplier to scale output of requantization
 /// * `output_zero` - Zero point of the requantization output

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -12,7 +12,6 @@ use dla_driver::layers::{conv2d, conv2d_bias, conv2d_bias_relu, conv2d_relu};
 use dla_driver::tensor3::{rescale, Order3, Tensor3};
 use dla_driver::tensor4::{Order4, Tensor4};
 use dla_driver::{Padding, Stride};
-use headsail_bsp::{sprint, sprintln};
 
 /// Converts C-types to DLA Tensors for use with the highlevel layer
 unsafe fn ffi_data_import(

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -14,21 +14,6 @@ use dla_driver::tensor4::{Order4, Tensor4};
 use dla_driver::{Padding, Stride};
 
 /// Converts C-types to DLA Tensors for use with the highlevel layer
-///
-/// # Arguments
-///
-/// * `input_data` - Input data  
-/// * `input_channels` - Number of channels in the input
-/// * `input_height` - Height of the input
-/// * `input_width` - Width of the input
-/// * `input_order` - Layout of the input data
-/// * `input_zero` - Possible zero point correction value
-/// * `kernel_data` - Kernel/weight data
-/// * `kernel_amount` - Number of output channels
-/// * `kernel_channels` - Number of input channels
-/// * `kernel_height` - Kernel height
-/// * `kernel_width` - Kernel width
-/// * `kernel_order` - Kernel data layout
 unsafe fn ffi_data_import(
     input_data: *const i8,
     input_channels: usize,
@@ -95,31 +80,6 @@ pub unsafe extern "C" fn dla_init() {
 }
 
 /// Executes Conv2D on DLA with given parameters and writes result to output buffer.
-///
-/// # Arguments
-///
-/// * `input_data` - Input data  
-/// * `kernel_data` - Kernel/weight data
-/// * `output` - Buffer for operation output
-/// * `input_channels` - Number of channels in the input
-/// * `input_height` - Height of the input
-/// * `input_width` - Width of the input
-/// * `input_order` - Layout of the input data
-/// * `input_zero` - Possible zero point correction value
-/// * `kernel_amount` - Number of output channels
-/// * `kernel_channels` - Number of input channels
-/// * `kernel_height` - Kernel height
-/// * `kernel_width` - Kernel width
-/// * `kernel_order` - Kernel data layout
-/// * `pad_top` - Amount of padding on top of the data
-/// * `pad_right` - Amount of padding on right side of the data
-/// * `pad_left` - Amount of padding on left side of the data
-/// * `pad_bottom` - Amount of padding on bottom of the data
-/// * `pad_value` - Integer value used for padding the data
-/// * `stride_x` - Horizontal stride
-/// * `stride_y` - Vertical stride
-/// * `mac_clip` - Amount of bits clipped at the end of the convolution
-/// * `pp_clip` - Amount of bits clipped at the end of the post processing
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d(
     input_data: *const i8,
@@ -185,31 +145,6 @@ pub unsafe extern "C" fn dla_conv2d(
 }
 
 /// Executes Conv2D + ReLU on DLA with given parameters and writes result to output buffer.
-///
-/// # Arguments
-///
-/// * `input_data` - Input data  
-/// * `kernel_data` - Kernel/weight data
-/// * `output` - Buffer for operation output
-/// * `input_channels` - Number of channels in the input
-/// * `input_height` - Height of the input
-/// * `input_width` - Width of the input
-/// * `input_order` - Layout of the input data
-/// * `input_zero` - Possible zero point correction value
-/// * `kernel_amount` - Number of output channels
-/// * `kernel_channels` - Number of input channels
-/// * `kernel_height` - Kernel height
-/// * `kernel_width` - Kernel width
-/// * `kernel_order` - Kernel data layout
-/// * `pad_top` - Amount of padding on top of the data
-/// * `pad_right` - Amount of padding on right side of the data
-/// * `pad_left` - Amount of padding on left side of the data
-/// * `pad_bottom` - Amount of padding on bottom of the data
-/// * `pad_value` - Integer value used for padding the data
-/// * `stride_x` - Horizontal stride
-/// * `stride_y` - Vertical stride
-/// * `mac_clip` - Amount of bits clipped at the end of the convolution
-/// * `pp_clip` - Amount of bits clipped at the end of the post processing
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_relu(
     input_data: *const i8,
@@ -277,31 +212,7 @@ pub unsafe extern "C" fn dla_conv2d_relu(
 /// Executes Conv2D + Bias on DLA with given parameters and writes result to output buffer.
 /// # Arguments
 ///
-/// * `input_data` - Input data  
-/// * `kernel_data` - Kernel/weight data
-/// * `bias` - Buffer containing bias data. NOTE: Bias is actually i16 in hardware, here we use 32 for TVM compatibility
-/// * `output` - Buffer for operation output
-/// * `input_channels` - Number of channels in the input
-/// * `input_height` - Height of the input
-/// * `input_width` - Width of the input
-/// * `input_order` - Layout of the input data
-/// * `input_zero` - Possible zero point correction value
-/// * `kernel_amount` - Number of output channels
-/// * `kernel_channels` - Number of input channels
-/// * `kernel_height` - Kernel height
-/// * `kernel_width` - Kernel width
-/// * `kernel_order` - Kernel data layout
-/// * `bias_length` - Size of the bias fifo
-/// * `pad_top` - Amount of padding on top of the data
-/// * `pad_right` - Amount of padding on right side of the data
-/// * `pad_left` - Amount of padding on left side of the data
-/// * `pad_bottom` - Amount of padding on bottom of the data
-/// * `pad_value` - Integer value used for padding the data
-/// * `stride_x` - Horizontal stride
-/// * `stride_y` - Vertical stride
-/// * `mac_clip` - Amount of bits clipped at the end of the convolution
-/// * `pp_clip` - Amount of bits clipped at the end of the post processing
-
+/// * `bias` - Bias is actually i16 in hardware, here we use 32 for TVM compatibility
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias(
     input_data: *const i8,
@@ -376,30 +287,7 @@ pub unsafe extern "C" fn dla_conv2d_bias(
 ///
 /// # Arguments
 ///
-/// * `input_data` - Input data  
-/// * `kernel_data` - Kernel/weight data
 /// * `bias` - Buffer containing bias data. NOTE: Bias is actually i16 in hardware, here we use 32 for TVM compatibility
-/// * `output` - Buffer for operation output
-/// * `input_channels` - Number of channels in the input
-/// * `input_height` - Height of the input
-/// * `input_width` - Width of the input
-/// * `input_order` - Layout of the input data
-/// * `input_zero` - Possible zero point correction value
-/// * `kernel_amount` - Number of output channels
-/// * `kernel_channels` - Number of input channels
-/// * `kernel_height` - Kernel height
-/// * `kernel_width` - Kernel width
-/// * `kernel_order` - Kernel data layout
-/// * `bias_length` - Size of the bias fifo
-/// * `pad_top` - Amount of padding on top of the data
-/// * `pad_right` - Amount of padding on right side of the data
-/// * `pad_left` - Amount of padding on left side of the data
-/// * `pad_bottom` - Amount of padding on bottom of the data
-/// * `pad_value` - Integer value used for padding the data
-/// * `stride_x` - Horizontal stride
-/// * `stride_y` - Vertical stride
-/// * `mac_clip` - Amount of bits clipped at the end of the convolution
-/// * `pp_clip` - Amount of bits clipped at the end of the post processing
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias_relu(
     input_data: *const i8,
@@ -484,34 +372,7 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
 
 /// # Arguments
 ///
-/// * `input_data` - Input data  
-/// * `kernel_data` - Kernel/weight data
 /// * `bias` - Buffer containing bias data. NOTE: Bias is actually i16 in hardware, here we use 32 for TVM compatibility
-/// * `output` - Buffer for operation output
-/// * `output_scale` - Multiplier to scale output of requantization
-/// * `output_zero` - Zero point of the requantization output
-/// * `input_scale` - Multiplier to scale input of requantization
-/// * `input_zero` - Zero point of the requantization input
-/// * `input_channels` - Number of channels in the input
-/// * `input_height` - Height of the input
-/// * `input_width` - Width of the input
-/// * `input_order` - Layout of the input data
-/// * `input_zero` - Possible zero point correction value
-/// * `kernel_amount` - Number of output channels
-/// * `kernel_channels` - Number of input channels
-/// * `kernel_height` - Kernel height
-/// * `kernel_width` - Kernel width
-/// * `kernel_order` - Kernel data layout
-/// * `bias_length` - Size of the bias fifo
-/// * `pad_top` - Amount of padding on top of the data
-/// * `pad_right` - Amount of padding on right side of the data
-/// * `pad_left` - Amount of padding on left side of the data
-/// * `pad_bottom` - Amount of padding on bottom of the data
-/// * `pad_value` - Integer value used for padding the data
-/// * `stride_x` - Horizontal stride
-/// * `stride_y` - Vertical stride
-/// * `mac_clip` - Amount of bits clipped at the end of the convolution
-/// * `pp_clip` - Amount of bits clipped at the end of the post processing
 #[no_mangle]
 pub unsafe extern "C" fn dla_tvm_qnn_conv2d(
     input_data: *const i8,

--- a/examples/hpc/dla-driver-ffi/src/lib.rs
+++ b/examples/hpc/dla-driver-ffi/src/lib.rs
@@ -9,9 +9,10 @@ use alloc::vec::Vec;
 use core::ffi::{c_char, CStr};
 use core::slice;
 use dla_driver::layers::{conv2d, conv2d_bias, conv2d_bias_relu, conv2d_relu};
-use dla_driver::tensor3::{Order3, Tensor3};
+use dla_driver::tensor3::{rescale, Order3, Tensor3};
 use dla_driver::tensor4::{Order4, Tensor4};
 use dla_driver::{Padding, Stride};
+use headsail_bsp::{sprint, sprintln};
 
 /// Converts C-types to DLA Tensors for use with the highlevel layer
 unsafe fn ffi_data_import(
@@ -20,6 +21,7 @@ unsafe fn ffi_data_import(
     input_height: usize,
     input_width: usize,
     input_order: *const c_char,
+    input_zero: i16,
     kernel_data: *const i8,
     kernel_amount: usize,
     kernel_channels: usize,
@@ -27,9 +29,15 @@ unsafe fn ffi_data_import(
     kernel_width: usize,
     kernel_order: *const c_char,
 ) -> (Tensor3<i8>, Tensor4<i8>) {
-    let input_data: Vec<i8> = unsafe {
+    let mut input_data: Vec<i8> = unsafe {
         slice::from_raw_parts(input_data, input_channels * input_height * input_width).to_vec()
     };
+
+    // Input zero point shift
+    input_data = input_data
+        .into_iter()
+        .map(|x| scale_as_i16(x, input_zero))
+        .collect();
 
     let input_order_string = unsafe { CStr::from_ptr(input_order).to_str().unwrap_unchecked() };
     let input_tensor = unsafe {
@@ -77,11 +85,12 @@ pub unsafe extern "C" fn dla_init() {
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d(
     input_data: *const i8,
+    kernel_data: *const i8,
+    output: *mut i8,
     input_channels: usize,
     input_height: usize,
     input_width: usize,
     input_order: *const c_char,
-    kernel_data: *const i8,
     kernel_amount: usize,
     kernel_channels: usize,
     kernel_height: usize,
@@ -96,7 +105,6 @@ pub unsafe extern "C" fn dla_conv2d(
     stride_y: u32,
     mac_clip: u32,
     pp_clip: u32,
-    output: *mut i8,
 ) {
     let (input_tensor, kernels_tensor) = unsafe {
         ffi_data_import(
@@ -105,6 +113,7 @@ pub unsafe extern "C" fn dla_conv2d(
             input_height,
             input_width,
             input_order,
+            0,
             kernel_data,
             kernel_amount,
             kernel_channels,
@@ -141,11 +150,12 @@ pub unsafe extern "C" fn dla_conv2d(
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_relu(
     input_data: *const i8,
+    kernel_data: *const i8,
+    output: *mut i8,
     input_channels: usize,
     input_height: usize,
     input_width: usize,
     input_order: *const c_char,
-    kernel_data: *const i8,
     kernel_amount: usize,
     kernel_channels: usize,
     kernel_height: usize,
@@ -160,7 +170,6 @@ pub unsafe extern "C" fn dla_conv2d_relu(
     stride_y: u32,
     mac_clip: u32,
     pp_clip: u32,
-    output: *mut i8,
 ) {
     let (input_tensor, kernels_tensor) = unsafe {
         ffi_data_import(
@@ -169,6 +178,7 @@ pub unsafe extern "C" fn dla_conv2d_relu(
             input_height,
             input_width,
             input_order,
+            0,
             kernel_data,
             kernel_amount,
             kernel_channels,
@@ -205,17 +215,18 @@ pub unsafe extern "C" fn dla_conv2d_relu(
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias(
     input_data: *const i8,
+    kernel_data: *const i8,
+    bias: *const i32, // NOTE: bias is actually i16 in hardware, here we use 32 for TVM compatability
+    output: *mut i8,
     input_channels: usize,
     input_height: usize,
     input_width: usize,
     input_order: *const c_char,
-    kernel_data: *const i8,
     kernel_amount: usize,
     kernel_channels: usize,
     kernel_height: usize,
     kernel_width: usize,
     kernel_order: *const c_char,
-    bias: *const i16,
     bias_length: usize,
     pad_top: u32,
     pad_right: u32,
@@ -226,7 +237,6 @@ pub unsafe extern "C" fn dla_conv2d_bias(
     stride_y: u32,
     mac_clip: u32,
     pp_clip: u32,
-    output: *mut i8,
 ) {
     let (input_tensor, kernels_tensor) = unsafe {
         ffi_data_import(
@@ -235,6 +245,7 @@ pub unsafe extern "C" fn dla_conv2d_bias(
             input_height,
             input_width,
             input_order,
+            0,
             kernel_data,
             kernel_amount,
             kernel_channels,
@@ -244,7 +255,7 @@ pub unsafe extern "C" fn dla_conv2d_bias(
         )
     };
 
-    let bias: Vec<i16> = unsafe { slice::from_raw_parts(bias, bias_length).to_vec() };
+    let bias: Vec<i16> = unsafe { slice::from_raw_parts(bias as *const i16, bias_length).to_vec() };
 
     let result = conv2d_bias(
         input_tensor,
@@ -274,17 +285,18 @@ pub unsafe extern "C" fn dla_conv2d_bias(
 #[no_mangle]
 pub unsafe extern "C" fn dla_conv2d_bias_relu(
     input_data: *const i8,
+    kernel_data: *const i8,
+    bias: *const i32,
+    output: *mut i8,
     input_channels: usize,
     input_height: usize,
     input_width: usize,
     input_order: *const c_char,
-    kernel_data: *const i8,
     kernel_amount: usize,
     kernel_channels: usize,
     kernel_height: usize,
     kernel_width: usize,
     kernel_order: *const c_char,
-    bias: *const i16,
     bias_length: usize,
     pad_top: u32,
     pad_right: u32,
@@ -295,7 +307,6 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
     stride_y: u32,
     mac_clip: u32,
     pp_clip: u32,
-    output: *mut i8,
 ) {
     let (input_tensor, kernels_tensor) = unsafe {
         ffi_data_import(
@@ -304,6 +315,7 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
             input_height,
             input_width,
             input_order,
+            0,
             kernel_data,
             kernel_amount,
             kernel_channels,
@@ -312,12 +324,14 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
             kernel_order,
         )
     };
-    let bias: Vec<i16> = unsafe { slice::from_raw_parts(bias, bias_length).to_vec() };
+
+    let bias: Vec<i32> = unsafe { slice::from_raw_parts(bias as *const i32, bias_length).to_vec() };
+    let bias_i16: Vec<i16> = bias.into_iter().map(|x| clip_i32_to_i16(x)).collect();
 
     let result = conv2d_bias_relu(
         input_tensor,
         kernels_tensor,
-        bias,
+        bias_i16,
         Some(Padding {
             top: pad_top,
             right: pad_right,
@@ -333,7 +347,139 @@ pub unsafe extern "C" fn dla_conv2d_bias_relu(
         Some(pp_clip),
         None,
     );
+
+    let input_order_string = unsafe { CStr::from_ptr(input_order).to_str().unwrap_unchecked() };
     unsafe {
-        core::ptr::copy_nonoverlapping(result.to_buffer().as_mut_ptr(), output, result.get_size())
+        core::ptr::copy_nonoverlapping(
+            result
+                .to_buffer_with_order(Order3::try_from(input_order_string).unwrap_unchecked())
+                .as_mut_ptr(),
+            output,
+            result.get_size(),
+        )
     };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dla_tvm_qnn_conv2d(
+    input_data: *const i8,
+    kernel_data: *const i8,
+    bias: *const i32,
+    output: *mut i8,
+    output_scale: *const f32,
+    output_zero: *const i32,
+    input_scale: *const f32,
+    input_zero: *const i32,
+    input_channels: usize,
+    input_height: usize,
+    input_width: usize,
+    input_order: *const c_char,
+    kernel_amount: usize,
+    kernel_channels: usize,
+    kernel_height: usize,
+    kernel_width: usize,
+    kernel_order: *const c_char,
+    bias_length: usize,
+    pad_top: u32,
+    pad_right: u32,
+    pad_left: u32,
+    pad_bottom: u32,
+    pad_value: i32,
+    stride_x: u32,
+    stride_y: u32,
+    mac_clip: u32,
+    pp_clip: u32,
+) {
+    let input_scale: Vec<f32> =
+        unsafe { slice::from_raw_parts(input_scale as *const f32, 1).to_vec() };
+
+    let input_zero: Vec<i32> =
+        unsafe { slice::from_raw_parts(input_zero as *const i32, 1).to_vec() };
+
+    let output_scale: Vec<f32> =
+        unsafe { slice::from_raw_parts(output_scale as *const f32, kernel_amount).to_vec() };
+
+    let output_zero: Vec<i32> =
+        unsafe { slice::from_raw_parts(output_zero as *const i32, 1).to_vec() };
+
+    let (input_tensor, kernels_tensor) = unsafe {
+        ffi_data_import(
+            input_data,
+            input_channels,
+            input_height,
+            input_width,
+            input_order,
+            (-1 * input_zero[0]) as i16,
+            kernel_data,
+            kernel_amount,
+            kernel_channels,
+            kernel_height,
+            kernel_width,
+            kernel_order,
+        )
+    };
+
+    let bias: Vec<i32> = unsafe { slice::from_raw_parts(bias as *const i32, bias_length).to_vec() };
+    let bias_i16: Vec<i16> = bias.into_iter().map(|x| clip_i32_to_i16(x)).collect();
+
+    let mut result = conv2d_bias_relu(
+        input_tensor,
+        kernels_tensor,
+        bias_i16,
+        Some(Padding {
+            top: pad_top,
+            right: pad_right,
+            left: pad_left,
+            bottom: pad_bottom,
+            padding_value: pad_value,
+        }),
+        Some(Stride {
+            x: stride_x,
+            y: stride_y,
+        }),
+        Some(mac_clip),
+        Some(pp_clip),
+        None,
+    );
+
+    // TVM requantization and clip
+    rescale(
+        &mut result,
+        u32::pow(2, pp_clip) as f32, //NOTE:(20240924 vaino-waltteri.granat@tuni.fi) Mitigate pp downscale
+        input_zero[0],
+        output_zero[0],
+        input_scale[0],
+        output_scale,
+    );
+
+    let input_order_string = unsafe { CStr::from_ptr(input_order).to_str().unwrap_unchecked() };
+
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            result
+                .to_buffer_with_order(Order3::try_from(input_order_string).unwrap_unchecked())
+                .as_mut_ptr(),
+            output,
+            result.get_size(),
+        )
+    };
+}
+fn clip_i32_to_i16(value: i32) -> i16 {
+    if value > i16::MAX as i32 {
+        return i16::MAX;
+    } else if value < i16::MIN as i32 {
+        return i16::MIN;
+    } else {
+        return value as i16;
+    }
+}
+
+fn scale_as_i16(input: i8, factor: i16) -> i8 {
+    let new_value = input as i16 + factor;
+    if new_value > 127 {
+        return 127;
+    } else if new_value < -128 {
+        return -128;
+    }
+    return new_value as i8;
 }


### PR DESCRIPTION
Our TVM codegen mandates a particular order for the external interface arguments and certain scaling operations to be done before and after qnn.conv2d call.