### PR TITLE
CI: out32 flag

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -183,6 +183,9 @@ jobs:
       image: antmicro/renode:1.14.0
       options: --user root
 
+    env:
+      # Enable 32-bit output, required for this test case
+      DLA_VP_OUT32: 1
     steps:
     - uses: actions/checkout@v4
     - name: Download artifact

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CI: 1
+  DLA_VP_QUIET: 1
   CARGO_TERM_COLOR: always
   RENODE_DIR: /opt/renode/
   # Used by renode-test to generate snapshots of failed tests

--- a/vp/devel/README.md
+++ b/vp/devel/README.md
@@ -10,3 +10,9 @@ The VP is structured as follows:
 | :-           | :-      |
 | headsail.repl  | Defines all headsail CPUs, memories and peripherals |
 
+## Supported environment variables
+
+| Variable     | Purpose |
+| :-:          | :- |
+| CI           | Suppresses stdout |
+| DLA_VP_OUT32 | Enable 32-bit output |

--- a/vp/devel/README.md
+++ b/vp/devel/README.md
@@ -14,5 +14,5 @@ The VP is structured as follows:
 
 | Variable     | Purpose |
 | :-:          | :- |
-| CI           | Suppresses stdout |
+| DLA_VP_QUIET | Suppresses stdout |
 | DLA_VP_OUT32 | Enable 32-bit output |

--- a/vp/devel/python_peripherals/DLA.py
+++ b/vp/devel/python_peripherals/DLA.py
@@ -1183,7 +1183,7 @@ class Dla:
                 res = execute_for_all_elements(self.mac.relu_native, res)
 
         # Prevent overflowing i16 range
-# NOTE: (20250312 vaino-waltteri.granat@tuni.fi) Some CI tests expect 32-bit output, which is not supported on ASIC but is supported by VP. Make this option only available in CI.
+        # NOTE: (20250312 vaino-waltteri.granat@tuni.fi) Some CI tests expect 32-bit output, which is not supported on ASIC but is supported by VP. Make this option only available in CI.
         if output_bit_width == 32 and os.environ.get("CI"):
             self.write_output(res, 32)
         else:

--- a/vp/devel/python_peripherals/DLA.py
+++ b/vp/devel/python_peripherals/DLA.py
@@ -1617,8 +1617,7 @@ if __name__ == "__main__":
 else:
     if request.isInit:
         # Supress all python print in CI
-        is_ci = os.environ.get("CI")
-        if not is_ci == None:
+        if os.environ.get("DLA_VP_QUIET"):
             sys.stdout = open(os.devnull, "w")
 
         # Initialized DLA

--- a/vp/devel/python_peripherals/DLA.py
+++ b/vp/devel/python_peripherals/DLA.py
@@ -1184,7 +1184,7 @@ class Dla:
 
         # Prevent overflowing i16 range
         # NOTE: (20250312 vaino-waltteri.granat@tuni.fi) Some CI tests expect 32-bit output, which is not supported on ASIC but is supported by VP. Make this option only available in CI.
-        if output_bit_width == 32 and os.environ.get("CI"):
+        if output_bit_width == 32 and os.environ.get("DLA_VP_OUT32"):
             self.write_output(res, 32)
         else:
             res = execute_for_all_elements(clip_value_to_i16, res)


### PR DESCRIPTION
Use feature-specific flags instead of generic "CI" flag.